### PR TITLE
Base: Export constants for non-union primitives

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -48,6 +48,15 @@ import type { Brand } from "../internal/index.js";
 export type WKApiRevision = "20170710";
 
 /**
+ * A constant representing the WaniKani API revision. This will match the revision module being imported from, or the
+ * latest revision when importing from the root module.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
+ * @category Base
+ */
+export const WK_API_REVISION: WKApiRevision = "20170710";
+
+/**
  * The common properties across all Collection items from the WaniKani API
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
@@ -147,6 +156,13 @@ export interface WKError {
 export type WKMaxLessonBatchSize = 10;
 
 /**
+ * The maximum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MAX_LESSON_BATCH_SIZE: WKMaxLessonBatchSize = 10;
+
+/**
  * The maximum level provided by WaniKani; used to calculate level ranges.
  *
  * @category Base
@@ -154,11 +170,25 @@ export type WKMaxLessonBatchSize = 10;
 export type WKMaxLevels = 60;
 
 /**
+ * The maximum level provided by WaniKani; exported for use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MAX_LEVELS: WKMaxLevels = 60;
+
+/**
  * The maximum number of SRS Stages used in WaniKani's SRS; used to calculate SRS Stage ranges.
  *
  * @category Base
  */
 export type WKMaxSrsStages = 9;
+
+/**
+ * The maximum number of SRS Stages used in WaniKani's SRS; exported for use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MAX_SRS_STAGES: WKMaxSrsStages = 9;
 
 /**
  * The maximum number of SRS Stages used in WaniKani's SRS, minus one; used to calculate SRS Stage ranges for reviews.
@@ -175,11 +205,26 @@ export type WKMaxSrsStagesMinusOne = 8;
 export type WKMinLessonBatchSize = 3;
 
 /**
+ * The minimum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MIN_LESSON_BATCH_SIZE: WKMinLessonBatchSize = 3;
+
+/**
  * The lowest number of levels that a WaniKani user has access to, when they are on a free subscription.
  *
  * @category Base
  */
 export type WKMinLevels = 3;
+
+/**
+ * The lowest number of levels that a WaniKani user has access to, when they are on a free subscription; exported for
+ * use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MIN_LEVELS: WKMinLevels = 3;
 
 /**
  * All types of parameters that can be passed to various endpoints across the WaniKani API.

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -184,6 +184,13 @@ export const WK_MAX_LEVELS: WKMaxLevels = 60;
 export type WKMaxSrsReviewStages = 8;
 
 /**
+ * The maximum number of SRS Stages used in WaniKani's reviews; exported for use in lieu of a Magic Number.
+ *
+ * @category Base
+ */
+export const WK_MAX_SRS_REVIEW_STAGES: WKMaxSrsReviewStages = 8;
+
+/**
  * The maximum number of SRS Stages used in WaniKani's SRS; used to calculate SRS Stage ranges.
  *
  * @category Base

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 /*
-This file exports all the types available in the recommended API version. Thereby, things MAY break in the future.
-Try sticking to imports from a specific version.
+This file exports all the types available in the recommended API revision. Thereby, things MAY break in the future.
+Try sticking to imports from a specific revision.
 */
 
 export { isWKDatableString, stringifyParameters } from "./v20170710.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,17 @@ This file exports all the types available in the recommended API revision. There
 Try sticking to imports from a specific revision.
 */
 
-export { isWKDatableString, stringifyParameters } from "./v20170710.js";
+export {
+	WK_API_REVISION,
+	WK_MAX_LESSON_BATCH_SIZE,
+	WK_MAX_LEVELS,
+	WK_MAX_SRS_REVIEW_STAGES,
+	WK_MAX_SRS_STAGES,
+	WK_MIN_LESSON_BATCH_SIZE,
+	WK_MIN_LEVELS,
+	isWKDatableString,
+	stringifyParameters,
+} from "./v20170710.js";
 
 export type {
 	WKApiRevision,

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -1,4 +1,14 @@
-export { isWKDatableString, stringifyParameters } from "./base/v20170710.js";
+export {
+	WK_API_REVISION,
+	WK_MAX_LESSON_BATCH_SIZE,
+	WK_MAX_LEVELS,
+	WK_MAX_SRS_REVIEW_STAGES,
+	WK_MAX_SRS_STAGES,
+	WK_MIN_LESSON_BATCH_SIZE,
+	WK_MIN_LEVELS,
+	isWKDatableString,
+	stringifyParameters,
+} from "./base/v20170710.js";
 
 export type {
 	WKAssignment,


### PR DESCRIPTION
Adds some exported constants for primitives that only have one possible value. This is good for those who don't like to use [Magic Numbers](https://en.wikipedia.org/wiki/Magic_number_(programming)) in their code.