### PR TITLE
Base: Deprecate WKMaxSrsStagesMinusOne for WKMaxSrsReviewStages

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -154,6 +154,13 @@ export type WKMaxLessonBatchSize = 10;
 export type WKMaxLevels = 60;
 
 /**
+ * The maximum number of SRS Stages used in WaniKani's reviews.
+ *
+ * @category Base
+ */
+export type WKMaxSrsReviewStages = 8;
+
+/**
  * The maximum number of SRS Stages used in WaniKani's SRS; used to calculate SRS Stage ranges.
  *
  * @category Base
@@ -164,6 +171,7 @@ export type WKMaxSrsStages = 9;
  * The maximum number of SRS Stages used in WaniKani's SRS, minus one; used to calculate SRS Stage ranges for reviews.
  *
  * @category Base
+ * @deprecated Use {@link WKMaxSrsReviewStages} instead.
  */
 export type WKMaxSrsStagesMinusOne = 8;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export type {
 	WKLevelProgressionParameters,
 	WKMaxLessonBatchSize,
 	WKMaxLevels,
+	WKMaxSrsReviewStages,
 	WKMaxSrsStages,
 	WKMaxSrsStagesMinusOne,
 	WKMinLessonBatchSize,

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -1,8 +1,8 @@
 import type {
 	WKCollection,
 	WKDatableString,
+	WKMaxSrsReviewStages,
 	WKMaxSrsStages,
-	WKMaxSrsStagesMinusOne,
 	WKResource,
 	WKReviewStatistic,
 	WKUpdatedAssignment,
@@ -115,7 +115,7 @@ export interface WKReviewData {
 	spaced_repetition_system_id: number;
 
 	/** The starting SRS stage interval, with valid values ranging from `1` to `8` */
-	starting_srs_stage: Range<1, WKMaxSrsStagesMinusOne>;
+	starting_srs_stage: Range<1, WKMaxSrsReviewStages>;
 
 	/**
 	 * Unique identifier of the associated subject.

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -19,6 +19,7 @@ export type {
 	WKError,
 	WKMaxLessonBatchSize,
 	WKMaxLevels,
+	WKMaxSrsReviewStages,
 	WKMaxSrsStages,
 	WKMaxSrsStagesMinusOne,
 	WKMinLessonBatchSize,


### PR DESCRIPTION
The type is being renamed to something a bit more descriptive for its purpose; the old type will be removed in 1.0.

Signed-off-by: Collin Bachman <collin@bachman.io>