### PR TITLE
Add Issue and Pull Request Templates to GitHub Repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: Report an issue encountered while using this package
+title: "Bug: "
+labels: ["bug"]
+assignees:
+  - bachmacintosh
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report! Please fill out the below form with as much info as possible.
+  - type: textarea
+    id: tried-doing
+    attributes:
+      label: What did you try to do?
+      description: "Describe here what actions you tried taking using the package."
+      placeholder: "e.g. Tried to use WKAssignmentPayload to start an assignment on WaniKani"
+    validations:
+      required: true
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: Code Snippet (if any)
+      description: If you have a snippet of code that can be tested against, please paste it here.
+      placeholder: "Your TypeScript/JavaScript code goes here..."
+      render: "TypeScript"
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      description: "Describe here what sort of outcome was expected when you attempted to do the above action."
+      placeholder: "e.g. Expected WaniKani to return HTTP Code 200 OK with a body of the started assignment."
+    validations:
+      required: true
+  - type: textarea
+    id: got
+    attributes:
+      label: What happened instead?
+      description: "Describe here the outcome that occurred instead of the expected behavior."
+      placeholder: "e.g. Got HTTP Error 422 because the payload body contents were invalid"
+    validations:
+      required: true
+  - type: input
+    id: ts-version
+    attributes:
+      label: TypeScript Version
+      description: The version of TypeScript you have installed in your dependencies
+      placeholder: "e.g. 4.8.4 or 5.2.3"
+    validations:
+      required: true
+  - type: textarea
+    id: tsconfig-json
+    attributes:
+      label: Your tsconfig.json File
+      description: Copy and paste the contents of the tsconfig.json file used to build your project.
+      placeholder: "Your tsconfig.json file contents here..."
+      render: "JSON"
+    validations:
+      required: true
+  - type: input
+    id: using-module
+    attributes:
+      label: Module Used
+      description: The WaniKani API revision-matched module being used; this can be left blank if using the root module.
+      placeholder: "e.g. v20170710"
+    validations:
+      required: false
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Any additional info?
+      description: "If there's anything else to consider with regards to the environment, feel free to add it here."
+      placeholder: "e.g. OS version, using types in a testing framework, etc."
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Agree to Contributing Terms
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: "WaniKani Bug Reports"
+    url: https://community.wanikani.com/c/wanikani/bugs-errors/15
+    about: "Please report any bugs/errors for the WaniKani App or API on the Community Forums (e.g. 500 Internal Server Error)."
+  - name: "WaniKani API Questions"
+    url: https://community.wanikani.com/c/wanikani/api-and-third-party-apps/6
+    about: "Consult the WaniKani Community Forums for general questions about the API itself."

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: "Package Discussion"
+    url: "https://community.wanikani.com/t/typescript-wanikani-api-types/59064?u=bachmac"
+    about: "Feel free to ask questions, leave feedback, etc. in the package's thread on the WaniKani Community Forums."
   - name: "WaniKani Bug Reports"
     url: https://community.wanikani.com/c/wanikani/bugs-errors/15
     about: "Please report any bugs/errors for the WaniKani App or API on the Community Forums (e.g. 500 Internal Server Error)."

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,68 @@
+name: Feature Request
+description: Request a new feature for the package, such as missing WaniKani API types, new variables/helper functions, etc.
+title: "Feature: "
+labels: ["enhancement"]
+assignees:
+  - bachmacintosh
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We welcome requests for features to be added to this package. Please fill out the form below -- thank you!
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Type of Feature
+      description: Select one of the options below indicating the type of feature requested.
+      multiple: false
+      options:
+        - "New/Missing WaniKani API Type for Item in API Docs"
+        - "New Type Provided by This Package"
+        - "New Constant or Other Variable"
+        - "New Helper Function/Type Guard"
+        - "Other (specify below)"
+    validations:
+      required: true
+  - type: textarea
+    id: feature-details
+    attributes:
+      label: New Feature Details
+      description: "Describe in more detail the sort of feature you are requesting here."
+      placeholder: "e.g. Describe a new type/constant/function/etc."
+    validations:
+      required: true
+  - type: textarea
+    id: code-snippet
+    attributes:
+      label: Code Snippet (if any)
+      description: If you have an example code snippet of the feature's application, you can paste it here.
+      placeholder: "Your TypeScript/JavaScript code goes here..."
+      render: "TypeScript"
+    validations:
+      required: false
+  - type: input
+    id: ts-version
+    attributes:
+      label: TypeScript Version
+      description: If this feature is limited to certain versions of TypeScript, indicated the version here (if you don't know, that's fine -- leave blank)
+      placeholder: "e.g. 4.8.4 or 5.2.3"
+    validations:
+      required: false
+  - type: textarea
+    id: other-info
+    attributes:
+      label: Any additional info?
+      description: "If there's anything else to consider with regards to the environment, feel free to add it here."
+      placeholder: "e.g. OS version, using types in a testing framework, etc."
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Agree to Contributing Terms
+      description: By submitting this issue, you agree to follow our [Contributing Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Contributing Guidelines and Code of Conduct
+          required: true
+        - label: I understand this is a feature request for the wanikani-api-types package, not for the WaniKani API itself
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,7 @@ This Pull Request:
 
 Its changes constitutes a:
 
+- [ ] Non-code change (i.e. no version bump)
 - [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
 - [ ] Forward-compatible Enhancement (i.e. minor version bump)
 - [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,3 +23,10 @@ Closes #
 ```
 
 Or some other information pertaining to the PR like breaking tests, etc.
+
+# Contribution Terms
+
+I understand that by submitting this Pull Request:
+
+- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
+- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,15 +6,22 @@ Add your description here.
 
 Closes #
 
-# Type of Pull Request
+# Nature of Pull Request
+
+This Pull Request:
 
 - [ ] Adds/Updates Type(s) described in the WaniKani API Docs
 - [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
 - [ ] Adds/Updates constants or other variables provided by the package
 - [ ] Adds/Updates Helper Functions/Type Guards provided by the package
-- [ ] Bug Fix
-- [ ] Enhancement
-- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version
+- [ ] Updates Documentation
+- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)
+
+Its code constitutes a:
+
+- [ ] Bug Fix (i.e. patch version bump)
+- [ ] Enhancement (i.e. minor version bump)
+- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version (i.e. MAJOR version bump)
 
 # Additional Info
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+Add your description here.
+
+# Related Issue(s)
+
+Closes #
+
+# Type of Pull Request
+
+- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
+- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
+- [ ] Adds/Updates constants or other variables provided by the package
+- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
+- [ ] Bug Fix
+- [ ] Enhancement
+- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version
+
+# Additional Info
+
+```typescript
+/* e.g. Your TypeScript Code Here */
+```
+
+Or some other information pertaining to the PR like breaking tests, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,10 +17,10 @@ This Pull Request:
 - [ ] Updates Documentation
 - [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)
 
-Its code constitutes a:
+Its changes constitutes a:
 
-- [ ] Bug Fix (i.e. patch version bump)
-- [ ] Enhancement (i.e. minor version bump)
+- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
+- [ ] Forward-compatible Enhancement (i.e. minor version bump)
 - [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version (i.e. MAJOR version bump)
 
 # Additional Info

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -21,7 +21,7 @@ Its changes constitutes a:
 
 - [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
 - [ ] Forward-compatible Enhancement (i.e. minor version bump)
-- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version (i.e. MAJOR version bump)
+- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)
 
 # Additional Info
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Please include in your description not only a detailed summary of the requested 
 
 ## Feature Implementations
 
-Open a Pull Request either as a completely new implementation for your own feature request, or to satisfy an existing Issue. Within the thread, please include an explanation of the improvement, and do your best to document any new or changed code. Please also be sure to label the Pull Request either `breaking change`, `enhancement`, `documentation`, or `bug` so it can be called out properly in release notes.
+Open a Pull Request either as a completely new implementation for your own feature request, or to satisfy an existing Issue. Within the thread, please include an explanation of the improvement, and do your best to document any new or changed code.
 
 This project uses sensible ESLint rules. Please make sure that your code passes the lint when possible. **Any pull requests that error out in ESLint will not be accepted until the errors are handled.** Any warnings should be dealt with either with code revision or a rule override (e.g. `eslint-disable-next-line`) if to rule violation cannot be avoided.
 


### PR DESCRIPTION
# Description

This PR adds some GitHub Issue and PR templates to make contributing to the project more streamlined.

# Related Issue(s)

See Issue #6 which is partially addressed by this PR.

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

There's also some minor wording changes to CONTRIBUTING.md to remove the PR labeling requirement (that can be done by those with write access).

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
