### PR TITLE
Add detailed import instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,52 @@ Major releases indicate a new version of the WaniKani API, or a [breaking change
 npm install --save-dev @bachmacintosh/wanikani-api-types
 ```
 
-Direct usage via the web is coming soon.
+Then, import using one of two methods.
+
+#### Specific API Revision (Recommended)
+
+The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
+
+```typescript
+import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-docs/v20170710.js";
+import { stringifyParameters } from "@bachmacintosh/wanikani-api-docs/v20170710.js";
+```
+
+#### Latest API Revision (Not Recommended)
+
+Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
+
+```typescript
+import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-docs";
+import { stringifyParameters } from "@bachmacintosh/wanikani-api-docs";
+```
+
+### Deno and Other Environments
+
+You can import the modules directly with `esm.sh`.
+
+**Be sure to replace `x.y.z` with your desired version number.**
+
+#### Specific API Revision (Recommended)
+
+The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
+
+```typescript
+import type {
+	WKAssignmentParameters,
+	WKDatableString,
+} from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710.js";
+import { stringifyParameters } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710.js";
+```
+
+#### Latest API Revision (Not Recommended)
+
+Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
+
+```typescript
+import type { WKAssignmentParameters, WKDatableString } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z";
+import { stringifyParameters } from "https://esm.sh/@bachmacintosh/wanikani-api-types@x.y.z";
+```
 
 ### Documentation
 


### PR DESCRIPTION
# Description

Updates the README to include more detailed import instructions. Specifically:

- Instructions for importing when using Deno or otherwise non-NPM environments through `esm.sh`
- Difference between importing the index module (latest API revision) vs revision-specific modules

# Related Issue(s)

See Issue #6 which is partially addressed by this PR.

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
