### PR TITLE
Reviews: Fix updated assignment type mismatch on WKCreatedReview

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -1,11 +1,11 @@
 import type {
+	WKAssignment,
 	WKCollection,
 	WKDatableString,
 	WKMaxSrsReviewStages,
 	WKMaxSrsStages,
 	WKResource,
 	WKReviewStatistic,
-	WKUpdatedAssignment,
 } from "../v20170710.js";
 import type { Range } from "../internal/index.js";
 
@@ -33,7 +33,7 @@ export interface WKCreatedReview extends WKResource {
 	/** The resources updated alongside creating the review */
 	resources_updated: {
 		/** The updated assignment upon creating the review */
-		assignment: WKUpdatedAssignment;
+		assignment: WKAssignment;
 
 		/** The updated review statistic upon creating the review */
 		review_statistic: WKReviewStatistic;


### PR DESCRIPTION
# Description

Fixes a type mismatch in `WKCreatedReview`; the assignment under `updated_resources` is just a `WKAssignment` without any additional properties, based on what was actually returned from WaniKani when testing creating a review vs. the response example in the WaniKani API Docs as of this writing.

# Related Issue(s)

Closes #13 

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

This should not impact any real world usage as the properties being removed from the updated assignment type were never actually returned. In a Zero Version, the narrowing of a type constitutes a minor version bump.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
