### PR TITLE
Docs: Mark WKUpdatedAssignment and WKUpdatedAssignmentData as Deprecated

### DIFF
--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -260,6 +260,9 @@ export type WKStartedAssignmentData = Omit<WKAssignmentData, "hidden">;
  *
  * @category Assignments
  * @category Resources
+ * @deprecated This type was originally created because the WaniKani API docs indicated that an updated assignment
+ * alongside a created review had additional properties, but further testing found this was not the case; this type will
+ * be removed in version 1.0, and should be substituted with {@link WKAssignment} instead.
  */
 export interface WKUpdatedAssignment extends WKResource {
 	/**
@@ -283,6 +286,9 @@ export interface WKUpdatedAssignment extends WKResource {
  *
  * @category Assignments
  * @category Data
+ * @deprecated This type was originally created because the WaniKani API docs indicated that an updated assignment
+ * alongside a created review had additional properties, but further testing found this was not the case; this type will
+ * be removed in version 1.0, and should be substituted with {@link WKAssignmentData} instead.
  */
 export interface WKUpdatedAssignmentData extends WKAssignmentData {
 	/**


### PR DESCRIPTION
# Description

Marks `WKUpdatedAssignment` and `WKUpdatedAssignmentData` as deprecated, to be removed in version 1.0. These types were made because the WaniKani API Docs indicated additional properties on updated assignments at the time, but based on testing the creation of a review, the response's updated assignment perfectly matches a `WKAssignment`, rendering this type redundant.

# Related Issue(s)

See #6 and #13 for related information on this Pull Request.

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>