### PR TITLE
Docs: Mark WKStartedAssignment and WKStartedAssignmentData as deprecated

### DIFF
--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -228,6 +228,9 @@ export interface WKAssignmentPayload {
  * @see {@link https://docs.api.wanikani.com/20170710/#start-an-assignment}
  * @category Assignments
  * @category Resources
+ * @deprecated This type was originally created because the WaniKani API docs indicated that a started assignment
+ * alongside a created review had different properties, but further testing found this was not the case; this type will
+ * be removed in version 1.0, and should be substituted with {@link WKAssignment} instead.
  */
 export interface WKStartedAssignment extends WKResource {
 	/**
@@ -252,6 +255,9 @@ export interface WKStartedAssignment extends WKResource {
  *
  * @category Assignments
  * @category Data
+ * @deprecated This type was originally created because the WaniKani API docs indicated that a started assignment
+ * alongside a created review had different properties, but further testing found this was not the case; this type will
+ * be removed in version 1.0, and should be substituted with {@link WKAssignmentData} instead.
  */
 export type WKStartedAssignmentData = Omit<WKAssignmentData, "hidden">;
 


### PR DESCRIPTION
# Description

The `WKStartedAssignment` and `WKStartedAssignmentData` types are redundant; the WaniKani API Docs indicated that the `hidden` property wasn't present on an updated assignment, but testing against the API itself indicates that the returned started assignment is a `WKAssignment` with all properties intact.

# Related Issue(s)

This addressed testing starting an assignment as outlined in #6 

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>