### PR TITLE
Study Materials: Fix and Clarify Types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ export type {
 	WKStartedAssignment,
 	WKStartedAssignmentData,
 	WKStudyMaterial,
+	WKStudyMaterialBaseData,
 	WKStudyMaterialCollection,
 	WKStudyMaterialCreatePayload,
 	WKStudyMaterialData,

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -1,5 +1,4 @@
 import type { WKCollection, WKDatableString, WKSubjectTuple, WKSubjectType } from "../v20170710.js";
-import type { Nullable } from "../internal/index.js";
 
 /**
  * Study materials store user-specific notes and synonyms for a given subject. The records are created as soon as the
@@ -26,16 +25,29 @@ export interface WKStudyMaterial {
 	data: WKStudyMaterialData;
 }
 
-interface WKStudyMaterialBaseData {
+/**
+ * Data found in all study materials whether they are being created/updated, or received from the WaniKani API
+ *
+ * @category Data
+ * @category Study Materials
+ * @remarks For creating study materials, use {@link WKStudyMaterialCreatePayload}; for updating study materials, use
+ * {@link WKStudyMaterialUpdatePayload}; for study materials received from the API, use {@link WKStudyMaterialData}
+ */
+export interface WKStudyMaterialBaseData {
 	/**
 	 * Free form note related to the meaning(s) of the associated subject.
 	 */
-	meaning_note: string;
+	meaning_note: string | null;
 
 	/**
 	 * Free form note related to the reading(s) of the associated subject.
 	 */
-	reading_note: string;
+	reading_note: string | null;
+
+	/**
+	 * Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
+	 */
+	meaning_synonyms: string[];
 }
 
 /**
@@ -69,9 +81,10 @@ export interface WKStudyMaterialCreatePayload extends WKStudyMaterialUpdatePaylo
 /**
  * Data for study material returned from the WaniKani API
  *
+ * @category Data
  * @category Study Materials
  */
-export interface WKStudyMaterialData extends Nullable<WKStudyMaterialBaseData> {
+export interface WKStudyMaterialData extends WKStudyMaterialBaseData {
 	/**
 	 * Timestamp when the study material was created.
 	 */
@@ -81,11 +94,6 @@ export interface WKStudyMaterialData extends Nullable<WKStudyMaterialBaseData> {
 	 * Indicates if the associated subject has been hidden, preventing it from appearing in lessons or reviews.
 	 */
 	hidden: boolean;
-
-	/**
-	 * Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
-	 */
-	meaning_synonyms: string[];
 
 	/**
 	 * Unique identifier of the associated subject.
@@ -138,10 +146,6 @@ export interface WKStudyMaterialParameters {
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#update-a-study-material}
  * @category Payloads
+ * @category Study Materials
  */
-export interface WKStudyMaterialUpdatePayload extends Partial<WKStudyMaterialBaseData> {
-	/**
-	 * Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
-	 */
-	meaning_synonyms?: string[];
-}
+export type WKStudyMaterialUpdatePayload = Partial<WKStudyMaterialBaseData>;

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -79,6 +79,7 @@ export type {
 
 export type {
 	WKStudyMaterial,
+	WKStudyMaterialBaseData,
 	WKStudyMaterialCollection,
 	WKStudyMaterialCreatePayload,
 	WKStudyMaterialData,


### PR DESCRIPTION
# Description

This PR tidies up some of the Study Materials types, and fixes a mistype where the `reading_note` and `reading_note` weren't nullable in all cases they should've been.

We also export `WKStudyMaterialBaseData` for documentation purposes, as it's now used as a type parameter.

# Related Issue(s)

These changes were prompted while testing the creation/update of study materials in #6 

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
