### PR TITLE
Renovate: Wait 3 Days before Updating a Dependency

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
 	"assignees": ["bachmacintosh"],
 	"rebaseWhen": "behind-base-branch",
 	"platformCommit": true,
+	"stabilityDays": 3,
 	"packageRules": [
 		{
 			"matchUpdateTypes": ["minor", "patch", "pin", "digest"],
@@ -27,10 +28,6 @@
 			"labels": ["typescript"],
 			"groupName": "TypeScript",
 			"dependencyDashboardApproval": true
-		},
-		{
-			"matchDatasources": ["npm"],
-			"stabilityDays": 3
 		}
 	]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,10 @@
 			"labels": ["typescript"],
 			"groupName": "TypeScript",
 			"dependencyDashboardApproval": true
+		},
+		{
+			"matchDatasources": ["npm"],
+			"stabilityDays": 3
 		}
 	]
 }


### PR DESCRIPTION
# Description

This PR configures Renovate (the bot responsible for dependency updates) to wait 3 days before updating any dependency. NPM allows package maintainers to pull a published package within 72 hours, so this aims to prevent the project linking to a broken package version.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
