### PR TITLE
Modules: Improve imports when using various NodeJS/TS setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Then, import using one of two methods.
 The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-docs/v20170710.js";
-import { stringifyParameters } from "@bachmacintosh/wanikani-api-docs/v20170710.js";
+import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-docs/dist/v20170710";
+import { stringifyParameters } from "@bachmacintosh/wanikani-api-docs/dist/v20170710";
 ```
 
 #### Latest API Revision (Not Recommended)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.3.0",
+	"version": "0.4.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",
@@ -12,14 +12,17 @@
 	"homepage": "https://wanikani-api-types.bachman.dev",
 	"type": "module",
 	"main": "./dist/index.js",
+	"module": "./dist/index.js",
 	"types": "./dist/index.d.ts",
 	"exports": {
 		".": {
 			"import": "./dist/index.js",
+			"require": "./dist/index.js",
 			"types": "./dist/index.d.ts"
 		},
-		"./v20170710.js": {
+		"./dist/v20170710": {
 			"import": "./dist/v20170710.js",
+			"require": "./dist/v20170710.js",
 			"types": "./dist/v20170710.d.ts"
 		}
 	},


### PR DESCRIPTION
# Description

Testing across multiple sample projects, it was found that importing an API revision module (e.g. v20170710) only worked on some projects, depending on how they resolved modules (e.g. pure TypeScript and Deno worked, Next.js did not). This PR updates the package's exports to be more compatible across all Node/Deno/TS projects by properly exporting the subpath.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
