### PR TITLE
Parameters: Add and Extend from Pagination Parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -1,5 +1,6 @@
 import type {
 	WKCollection,
+	WKCollectionParameters,
 	WKDatableString,
 	WKMaxLevels,
 	WKMaxSrsStages,
@@ -125,7 +126,7 @@ export interface WKAssignmentData {
  * @category Assignments
  * @category Parameters
  */
-export interface WKAssignmentParameters {
+export interface WKAssignmentParameters extends WKCollectionParameters {
 	/**
 	 * Only assignments available at or after this time are returned.
 	 */

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -133,11 +133,15 @@ export interface WKCollection {
 export interface WKCollectionParameters {
 	/**
 	 * Get a collection's next page containing `pages.per_page` resources after the given ID.
+	 *
+	 * This will take precedence over `page_before_id` if both are specified.
 	 */
 	page_after_id?: number;
 
 	/**
 	 * Get a collection's previous page containing `pages.per_page` resources before the given ID.
+	 *
+	 * The `page_after_id` parameter takes precedence over this if it is specified.
 	 */
 	page_before_id?: number;
 }

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -125,6 +125,24 @@ export interface WKCollection {
 }
 
 /**
+ * Query string parameters that can be send to any WaniKani API collection endpoint.
+ *
+ * @category Base
+ * @category Parameters
+ */
+export interface WKCollectionParameters {
+	/**
+	 * Get a collection's next page containing `pages.per_page` resources after the given ID.
+	 */
+	page_after_id?: number;
+
+	/**
+	 * Get a collection's previous page containing `pages.per_page` resources before the given ID.
+	 */
+	page_before_id?: number;
+}
+
+/**
  * A `string` sent to/returned from the WaniKani API that can be converted into a JavaScript `Date` object
  *
  * @category Base

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -141,7 +141,7 @@ export interface WKCollectionParameters {
 	/**
 	 * Get a collection's previous page containing `pages.per_page` resources before the given ID.
 	 *
-	 * The `page_after_id` parameter takes precedence over this if it is specified.
+	 * The `page_after_id` parameter takes precedence over this if it is specified alongside this parameter.
 	 */
 	page_before_id?: number;
 }

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -125,7 +125,7 @@ export interface WKCollection {
 }
 
 /**
- * Query string parameters that can be send to any WaniKani API collection endpoint.
+ * Query string parameters that can be sent to any WaniKani API collection endpoint.
  *
  * @category Base
  * @category Parameters

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -456,7 +456,7 @@ export function isWKDatableString(possibleWKDatableString: unknown): possibleWKD
  * @returns A query string of all the parameters, which can be added to a base URL
  * @category Base
  */
-export function stringifyParameters(params: WKParameters): string {
+export function stringifyParameters<T extends WKCollectionParameters>(params: T): string {
 	if (typeof params !== "object") {
 		throw new TypeError();
 	}

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export type {
 	WKAssignmentParameters,
 	WKAssignmentPayload,
 	WKCollection,
+	WKCollectionParameters,
 	WKCreatedReview,
 	WKDatableString,
 	WKError,

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -1,4 +1,4 @@
-import type { WKCollection, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
 import type { Range } from "../internal/index.js";
 
 /**
@@ -97,7 +97,7 @@ export interface WKLevelProgressionData {
  * @category Level Progressions
  * @category Parameters
  */
-export interface WKLevelProgressionParameters {
+export interface WKLevelProgressionParameters extends WKCollectionParameters {
 	/**
 	 * Only level progressions where `data.id` matches one of the array values are returned.
 	 */

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -1,4 +1,4 @@
-import type { WKCollection, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
 import type { Range } from "../internal/index.js";
 
 /**
@@ -77,7 +77,7 @@ export interface WKResetData {
  * @category Parameters
  * @category Resets
  */
-export interface WKResetParameters {
+export interface WKResetParameters extends WKCollectionParameters {
 	/**
 	 * Only resets where `data.id` matches one of the array values are returned.
 	 */

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -1,4 +1,11 @@
-import type { WKCollection, WKDatableString, WKResource, WKSubjectTuple, WKSubjectType } from "../v20170710.js";
+import type {
+	WKCollection,
+	WKCollectionParameters,
+	WKDatableString,
+	WKResource,
+	WKSubjectTuple,
+	WKSubjectType,
+} from "../v20170710.js";
 
 /**
  * Review statistics summarize the activity recorded in reviews. They contain sum the number of correct and incorrect
@@ -122,7 +129,7 @@ export interface WKReviewStatisticData {
  * @category Parameters
  * @category Review Statistics
  */
-export interface WKReviewStatisticParameters {
+export interface WKReviewStatisticParameters extends WKCollectionParameters {
 	/**
 	 * Return review statistics with a matching value in the `hidden` attribute
 	 */

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -1,6 +1,7 @@
 import type {
 	WKAssignment,
 	WKCollection,
+	WKCollectionParameters,
 	WKDatableString,
 	WKMaxSrsReviewStages,
 	WKMaxSrsStages,
@@ -130,7 +131,7 @@ export interface WKReviewData {
  * @category Parameters
  * @category Reviews
  */
-export interface WKReviewParameters {
+export interface WKReviewParameters extends WKCollectionParameters {
 	/** Only reviews where `data.assignment_id` matches one of the array values are returned. */
 	assignment_ids?: number[];
 

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -1,4 +1,4 @@
-import type { WKCollection, WKDatableString, WKResource } from "../v20170710.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKResource } from "../v20170710.js";
 
 /**
  * Available spaced repetition systems used for calculating `srs_stage` changes to Assignments and Reviews. Has
@@ -94,7 +94,7 @@ export interface WKSpacedRepetitionSystemData {
  * @category Parameters
  * @category Spaced Repetition Systems
  */
-export interface WKSpacedRepetitionSystemParameters {
+export interface WKSpacedRepetitionSystemParameters extends WKCollectionParameters {
 	/**
 	 * Only `spaced_repetition_systems` where `data.id` matches one of the array values are returned.
 	 */

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -1,4 +1,10 @@
-import type { WKCollection, WKDatableString, WKSubjectTuple, WKSubjectType } from "../v20170710.js";
+import type {
+	WKCollection,
+	WKCollectionParameters,
+	WKDatableString,
+	WKSubjectTuple,
+	WKSubjectType,
+} from "../v20170710.js";
 
 /**
  * Study materials store user-specific notes and synonyms for a given subject. The records are created as soon as the
@@ -113,7 +119,7 @@ export interface WKStudyMaterialData extends WKStudyMaterialBaseData {
  * @category Parameters
  * @category Study Materials
  */
-export interface WKStudyMaterialParameters {
+export interface WKStudyMaterialParameters extends WKCollectionParameters {
 	/**
 	 * Return study materials with a matching value in the `hidden` attribute
 	 */

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -1,5 +1,6 @@
 import type {
 	WKCollection,
+	WKCollectionParameters,
 	WKDatableString,
 	WKMaxLevels,
 	WKResource,
@@ -481,7 +482,7 @@ export interface WKSubjectMeaning {
  * @category Parameters
  * @category Subjects
  */
-export interface WKSubjectParameters {
+export interface WKSubjectParameters extends WKCollectionParameters {
 	/**
 	 * Only subjects where `data.id` matches one of the array values are returned.
 	 */

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -25,6 +25,7 @@ export type {
 export type {
 	WKApiRevision,
 	WKCollection,
+	WKCollectionParameters,
 	WKDatableString,
 	WKError,
 	WKMaxLessonBatchSize,

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -1,4 +1,4 @@
-import type { WKCollection, WKDatableString, WKResource } from "../v20170710.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKResource } from "../v20170710.js";
 
 /**
  * Available voice actors used for vocabulary reading pronunciation audio.
@@ -71,7 +71,7 @@ export interface WKVoiceActorData {
  * @category Parameters
  * @category Voice Actors
  */
-export interface WKVoiceActorParameters {
+export interface WKVoiceActorParameters extends WKCollectionParameters {
 	/**
 	 * Only `voice_actors` where `data.id` matches one of the array values are returned.
 	 */


### PR DESCRIPTION
# Description
To paginate through collections in the WaniKani API, you can pass a `page_before_id` or `page_after_id` included in next and previous page URLs' query strings. Since this can be done on any collection, it makes sense to extend from this type.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

Since `WKParameters` was only used to bind together collection parameters, we can deprecate it in another PR in favor of `WKCollectionParameters`.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>