### PR TITLE
Docs: Mark WKParameters as Deprecated

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -268,6 +268,8 @@ export const WK_MIN_LEVELS: WKMinLevels = 3;
  *
  * @category Base
  * @category Parameters
+ * @deprecated Use a type that extends {@link WKCollectionParameters} instead. This union type will be removed in
+ * version 1.0.
  */
 export type WKParameters =
 	| WKAssignmentParameters


### PR DESCRIPTION
# Description

This PR marks `WKParameters` as deprecated in the documentation. This was a union type that was used to narrow allowed types for `stringifyParameters()`, but now that we have a base type `WKCollectionParameters` that the other parameter types extend from, and are now using as an extended Type Parameter in `stringifyParameters()`, this type is no longer needed and can be removed in 1.0.

# Related Issue(s)

See #25 for more info on `WKCollectionParameters`

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>