### PR TITLE
README: Fix last import example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ We provide a helper function, `stringifyParameters`, that accepts any of the Par
 Here's a quick example code snippet that lays the foundation of fetching a collection of assignments, possibly using an old `data_updated_at` value from a previous collection of assignments, or a date calculated from a time period library.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types/v20170710.js";
-import { stringifyParameters } from "@bachmacintosh/wanikani-api-types/v20170710.js";
+import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types//distv20170710.js";
+import { stringifyParameters } from "@bachmacintosh/wanikani-api-types/dist/v20170710.js";
 
 function getAssignments(newerThan?: WKDatableString | Date) {
 	let params: WKAssignmentParameters = {};

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ We provide a helper function, `stringifyParameters`, that accepts any of the Par
 Here's a quick example code snippet that lays the foundation of fetching a collection of assignments, possibly using an old `data_updated_at` value from a previous collection of assignments, or a date calculated from a time period library.
 
 ```typescript
-import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types//distv20170710.js";
+import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wanikani-api-types/dist/v20170710.js";
 import { stringifyParameters } from "@bachmacintosh/wanikani-api-types/dist/v20170710.js";
 
 function getAssignments(newerThan?: WKDatableString | Date) {


### PR DESCRIPTION
# Description

This PR updates the last import example in the README to properly reflect importing a specific API revision module.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>