### PR TITLE
Docs: Use Custom Typedoc Theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 node_modules
 dist
-docs
+/docs
 
 # macOS files
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.5.0",
+	"version": "0.5.1",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	},
 	"scripts": {
 		"build": "rimraf dist && tsc",
+		"prebuild:docs": "tsc ./src/internal/docs/MethodsTheme.cts --target es2020 --module commonjs --outDir ./dist/internal/docs",
 		"build:docs": "typedoc",
 		"lint": "eslint . && prettier --check .",
 		"lint:fix": "eslint --fix . && prettier --write .",

--- a/src/internal/docs/MethodsTheme.cts
+++ b/src/internal/docs/MethodsTheme.cts
@@ -1,0 +1,98 @@
+import type { Application, PageEvent, RenderTemplate } from "typedoc";
+import { DeclarationReflection, DefaultTheme, ReflectionKind, UrlMapping } from "typedoc";
+
+interface TemplateMapping {
+    /**
+     * {@link DeclarationReflection.kind} this rule applies to.
+     */
+    kind: ReflectionKind[];
+
+    /**
+     * The name of the directory the output files should be written to.
+     */
+    directory: string;
+
+    /**
+     * The name of the template that should be used to render the reflection.
+     * 
+     */
+    /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Adapted from typedoc default theme. */
+    template: RenderTemplate<PageEvent<any>>;
+}
+
+
+export class MethodsTheme extends DefaultTheme{
+	public myMappings: TemplateMapping[] = [
+        {
+            kind: [ReflectionKind.Class],
+            directory: "classes",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.Interface],
+            directory: "interfaces",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.Enum],
+            directory: "enums",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.Namespace, ReflectionKind.Module],
+            directory: "modules",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.TypeAlias],
+            directory: "types",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.Function],
+            directory: "methods",
+            template: this.reflectionTemplate,
+        },
+        {
+            kind: [ReflectionKind.Variable],
+            directory: "variables",
+            template: this.reflectionTemplate,
+        },
+    ];
+
+	public buildUrls(reflection: DeclarationReflection, urls: UrlMapping[]): UrlMapping[] {
+		const mapping = this._getMyMapping(reflection);
+		if (mapping) {
+            if ( typeof reflection.url === "undefined" || !DefaultTheme.URL_PREFIX.test(reflection.url)) {
+                const url = [mapping.directory, `${DefaultTheme.getUrl(reflection)}.html`].join("/");
+                urls.push(new UrlMapping(url, reflection, mapping.template));
+
+                reflection.url = url;
+                reflection.hasOwnDocument = true;
+            }
+
+            reflection.traverse((child) => {
+                if (child instanceof DeclarationReflection) {
+                    this.buildUrls(child, urls);
+                } else {
+                    DefaultTheme.applyAnchorUrl(child, reflection);
+                }
+                return true;
+            });
+        } else if (reflection.parent) {
+            DefaultTheme.applyAnchorUrl(reflection, reflection.parent);
+        }
+
+        return urls;
+	}
+
+	private _getMyMapping(reflection: DeclarationReflection): TemplateMapping | undefined {
+        return this.myMappings.find((mapping) => {
+					return reflection.kindOf(mapping.kind)}
+					);
+    }
+}
+
+export function load(app: Application): void {
+	app.renderer.defineTheme("methodsTheme", MethodsTheme);
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,6 @@
 		"isolatedModules": true,
 		"exactOptionalPropertyTypes": true
 	},
-	"include": ["src/**/*.ts"],
+	"include": ["src/**/*.ts", "src/internal/docs/MethodsTheme.cts"],
 	"exclude": ["dist/**", "tests/**", "node_modules/**"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,8 @@
 	"$schema": "https://typedoc.org/schema.json",
 	"entryPoints": ["./src/v20170710.ts", "./src/index.ts"],
 	"out": "docs",
+	"plugin": ["./dist/internal/docs/MethodsTheme.cjs"],
+	"theme": "methodsTheme",
 	"cleanOutputDir": true,
 	"categorizeByGroup": false,
 	"categoryOrder": ["Base", "Collections", "Data", "Parameters", "Payloads", "Reports", "Resources", "*"],


### PR DESCRIPTION
# Description

Cloudflare Pages reserves the `functions` folder for running Pages Functions, and does some unusual stuff with regards to headers and rendering the response. So we're overriding some rendering logic in typedoc's default theme so that function documentation is rendered under a `methods` folder instead.

# Related Issue(s)

Closes #28 

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

There might be a breaking test with regards to building docs. We'll mitigate it if needed.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>