### PR TITLE
Study Materials: Add missing WKResource extend

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.5.1",
+	"version": "0.5.2",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -2,6 +2,7 @@ import type {
 	WKCollection,
 	WKCollectionParameters,
 	WKDatableString,
+	WKResource,
 	WKSubjectTuple,
 	WKSubjectType,
 } from "../v20170710.js";
@@ -14,7 +15,7 @@ import type {
  * @category Resources
  * @category Study Materials
  */
-export interface WKStudyMaterial {
+export interface WKStudyMaterial extends WKResource {
 	/**
 	 * A unique number identifying the study material.
 	 */


### PR DESCRIPTION
# Description

This PR extends `WKStudyMaterial` by `WKResource` like all other resource types. 

# Related Issue(s)

This was discovered while testing responses in #6 

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
