### PR TITLE
Subjects: Various Improvements to Subject Types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.5.2",
+	"version": "0.6.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -5,7 +5,6 @@ import type {
 	WKMaxLevels,
 	WKResource,
 	WKSubjectTuple,
-	WKSubjectType,
 } from "../v20170710.js";
 import type { Range } from "../internal/index.js";
 
@@ -21,7 +20,7 @@ import type { Range } from "../internal/index.js";
  * @category Resources
  * @category Subjects
  */
-export interface WKKanji extends WKSubject {
+export interface WKKanji extends WKResource {
 	/**
 	 * The kind of object returned.
 	 */
@@ -40,7 +39,7 @@ export interface WKKanji extends WKSubject {
  * @category Collections
  * @category Subjects
  */
-export interface WKKanjiCollection extends WKSubjectCollection {
+export interface WKKanjiCollection extends WKCollection {
 	/**
 	 * An array of returned kanji subjects.
 	 */
@@ -155,7 +154,7 @@ export interface WKKanjiReading {
  * @category Resources
  * @category Subjects
  */
-export interface WKRadical extends WKSubject {
+export interface WKRadical extends WKResource {
 	/**
 	 * The kind of object returned.
 	 */
@@ -250,7 +249,7 @@ export interface WKRadicalCharacterImageSvgMetadata {
  * @category Collections
  * @category Subjects
  */
-export interface WKRadicalCollection extends WKSubjectCollection {
+export interface WKRadicalCollection extends WKCollection {
 	/**
 	 * An array of returned radical subjects.
 	 */
@@ -331,22 +330,7 @@ export interface WKRadicalData extends WKSubjectData {
  * @category Resources
  * @category Subjects
  */
-export interface WKSubject extends WKResource {
-	/**
-	 * A unique number identifying the subject.
-	 */
-	id: number;
-
-	/**
-	 * The kind of object returned.
-	 */
-	object: WKSubjectType;
-
-	/**
-	 * Subject data.
-	 */
-	data: WKKanjiData | WKRadicalData | WKVocabularyData;
-}
+export type WKSubject = WKKanji | WKRadical | WKVocabulary;
 
 /**
  * A subject's auxilliary meanings.
@@ -526,7 +510,7 @@ export interface WKSubjectParameters extends WKCollectionParameters {
  * @category Resources
  * @category Subjects
  */
-export interface WKVocabulary extends WKSubject {
+export interface WKVocabulary extends WKResource {
 	/**
 	 * The kind of object returned.
 	 */
@@ -545,7 +529,7 @@ export interface WKVocabulary extends WKSubject {
  * @category Collections
  * @category Subjects
  */
-export interface WKVocabularyCollection extends WKSubjectCollection {
+export interface WKVocabularyCollection extends WKCollection {
 	/**
 	 * An array of returned vocabulary subjects.
 	 */

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -22,6 +22,11 @@ import type { Range } from "../internal/index.js";
  */
 export interface WKKanji extends WKResource {
 	/**
+	 * A unique number identifying the kanji.
+	 */
+	id: number;
+
+	/**
 	 * The kind of object returned.
 	 */
 	object: "kanji";
@@ -155,6 +160,11 @@ export interface WKKanjiReading {
  * @category Subjects
  */
 export interface WKRadical extends WKResource {
+	/**
+	 * A unique number identifying the radical.
+	 */
+	id: number;
+
 	/**
 	 * The kind of object returned.
 	 */
@@ -511,6 +521,11 @@ export interface WKSubjectParameters extends WKCollectionParameters {
  * @category Subjects
  */
 export interface WKVocabulary extends WKResource {
+	/**
+	 * A unique number identifying the vocabulary.
+	 */
+	id: number;
+
 	/**
 	 * The kind of object returned.
 	 */


### PR DESCRIPTION
# Description

This PR does some refactoring for the Subject resource types.

1. It makes the `WKSubject` type more narrowed based on the `object` property of the resource. So now the type can be narrowed down to either `WKKanji`, `WKRadical` or `WKVocabulary` based on `object` values of `kanji`, `radical`, or `vocabulary` respectively.
2. The individual subject types -- `WKKanji`, `WKRadical`, and `WKVocabulary` now directly extend `WKResource`. This better reflects the notion that while subjects have some common data amongst each other regardless of type, WaniKani still documents them as being separate resources.
3. Their respective collection types -- `WKKanjiCollection`, `WKRadicalCollection`, and `WKVocabularyCollection` -- now directly extend `WKCollection` for the same reasons. Just like before, if a collection of mixed subjects is expected, `WKSubjectCollection` is still available to use.

# Related Issue(s)

Closes #

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

There is a breaking change where if someone relied on uniting the subjects under `WKSubject` or `WKSubjectCollection` (e.g. a Type Parameter `T extends WKSubject` or `T extends WKSubjectCollection`), they will need to refactor their code to instead either use those types directly instead of extending, or using a specific subject resource/collection e.g. `WKKanji`, `WKKanjiCollection`, etc.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
