### PR TITLE
Base: Improvements to WKError Narrowing

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -162,12 +162,47 @@ export interface WKError {
 	/**
 	 * A message string that describes the error.
 	 */
-	error?: string;
+	error: string;
 
 	/**
 	 * An HTTP status code indicating the type of error.
 	 */
 	code: number;
+
+	/**
+	 * An error will never include a `data` property.
+	 */
+	data?: never;
+
+	/**
+	 * An error will never include a `data_updated_at` property.
+	 */
+	data_updated_at?: never;
+
+	/**
+	 * An error will never include an `id` property.
+	 */
+	id?: never;
+
+	/**
+	 * An error will never include an `object` property.
+	 */
+	object?: never;
+
+	/**
+	 * An error will never include a `pages` property.
+	 */
+	pages?: never;
+
+	/**
+	 * An error will never include a `total_count` property.
+	 */
+	total_count?: never;
+
+	/**
+	 * An error will never include a `url` property.
+	 */
+	url?: never;
 }
 
 /**


### PR DESCRIPTION
# Description

This PR updates `WKError` by:

1. Making the `error` property as always present, as it seems to always be returned and worst case reflects the HTTP status code
2. Adds `never` types for properties found on Collections/Reports/Resources to make type narrowing better (e.g. if you have a function that can return `WKUser | WKError` you can check for the `error` property to narrow down to `WKError`)

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
