### PR TITLE
Assignments: Fix Type of srs_stage Parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.6.0",
+	"version": "0.6.1",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -178,7 +178,7 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
 	 * Only assignments where `data.srs_stage` matches one of the array values are returned. Valid values range from `0`
 	 * to `9`
 	 */
-	srs_stages?: Range<0, WKMaxSrsStages>;
+	srs_stages?: Range<0, WKMaxSrsStages>[];
 
 	/**
 	 * When set to `true`, returns assignments that have a value in `data.started_at`. Returns assignments with a `null`


### PR DESCRIPTION
# Description

This PR fixes the `srs_stages` property on `WKAssignmentParameters`. It was supposed to be typed as an array, not a single number.

# Related Issue(s)

Found while testing parameters in #6 

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
