### PR TITLE
Parameters: Raise common parameters to WKCollectionParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.6.1",
+	"version": "0.7.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -197,11 +197,6 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
 	 * `data.unlocked_at` if `false`.
 	 */
 	unlocked?: boolean;
-
-	/**
-	 * Only assignments updated after this time, in ISO-8601 format, are returned.
-	 */
-	updated_after?: Date | WKDatableString;
 }
 
 /**

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -149,11 +149,6 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
 	hidden?: boolean;
 
 	/**
-	 * Only assignments where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * When set to `true`, returns assignments which are immediately available for lessons
 	 */
 	immediately_available_for_lessons?: boolean;

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -132,6 +132,11 @@ export interface WKCollection {
  */
 export interface WKCollectionParameters {
 	/**
+	 * Only resources where `data.id` matches one of the array values are returned.
+	 */
+	ids?: number[];
+
+	/**
 	 * Get a collection's next page containing `pages.per_page` resources after the given ID.
 	 *
 	 * This will take precedence over `page_before_id` if both are specified.

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -149,6 +149,11 @@ export interface WKCollectionParameters {
 	 * The `page_after_id` parameter takes precedence over this if it is specified alongside this parameter.
 	 */
 	page_before_id?: number;
+
+	/**
+	 * Only resources updated after this time are returned.
+	 */
+	updated_after?: Date | WKDatableString;
 }
 
 /**

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -97,9 +97,4 @@ export interface WKLevelProgressionData {
  * @category Level Progressions
  * @category Parameters
  */
-export interface WKLevelProgressionParameters extends WKCollectionParameters {
-	/**
-	 * Only level progressions updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
-}
+export type WKLevelProgressionParameters = WKCollectionParameters;

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -99,11 +99,6 @@ export interface WKLevelProgressionData {
  */
 export interface WKLevelProgressionParameters extends WKCollectionParameters {
 	/**
-	 * Only level progressions where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Only level progressions updated after this time are returned.
 	 */
 	updated_after?: Date | WKDatableString;

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -77,9 +77,4 @@ export interface WKResetData {
  * @category Parameters
  * @category Resets
  */
-export interface WKResetParameters extends WKCollectionParameters {
-	/**
-	 * Only resets updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
-}
+export type WKResetParameters = WKCollectionParameters;

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -79,11 +79,6 @@ export interface WKResetData {
  */
 export interface WKResetParameters extends WKCollectionParameters {
 	/**
-	 * Only resets where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Only resets updated after this time are returned.
 	 */
 	updated_after?: Date | WKDatableString;

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -155,9 +155,4 @@ export interface WKReviewStatisticParameters extends WKCollectionParameters {
 	 * `radical`, `kanji`, or `vocabulary`.
 	 */
 	subject_types?: WKSubjectTuple;
-
-	/**
-	 * Only review statistics updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
 }

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -136,11 +136,6 @@ export interface WKReviewStatisticParameters extends WKCollectionParameters {
 	hidden?: boolean;
 
 	/**
-	 * Only review statistics where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Return review statistics where the `percentage_correct` is greater than the value.
 	 */
 	percentages_greater_than?: number;

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -137,9 +137,6 @@ export interface WKReviewParameters extends WKCollectionParameters {
 
 	/** Only reviews where `data.subject_id` matches one of the array values are returned. */
 	subject_ids?: number[];
-
-	/** Only reviews updated after this time are returned. */
-	updated_after?: Date | WKDatableString;
 }
 
 /**

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -135,9 +135,6 @@ export interface WKReviewParameters extends WKCollectionParameters {
 	/** Only reviews where `data.assignment_id` matches one of the array values are returned. */
 	assignment_ids?: number[];
 
-	/** Only reviews where `data.id` matches one of the array values are returned. */
-	ids?: number[];
-
 	/** Only reviews where `data.subject_id` matches one of the array values are returned. */
 	subject_ids?: number[];
 

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -96,11 +96,6 @@ export interface WKSpacedRepetitionSystemData {
  */
 export interface WKSpacedRepetitionSystemParameters extends WKCollectionParameters {
 	/**
-	 * Only `spaced_repetition_systems` where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Only `spaced_repetition_systems` updated after this time are returned.
 	 */
 	updated_after?: Date | WKDatableString;

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -94,12 +94,7 @@ export interface WKSpacedRepetitionSystemData {
  * @category Parameters
  * @category Spaced Repetition Systems
  */
-export interface WKSpacedRepetitionSystemParameters extends WKCollectionParameters {
-	/**
-	 * Only `spaced_repetition_systems` updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
-}
+export type WKSpacedRepetitionSystemParameters = WKCollectionParameters;
 
 /**
  * An individual Spaced Repetition System (SRS) Stage

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -136,11 +136,6 @@ export interface WKStudyMaterialParameters extends WKCollectionParameters {
 	 * are: `radical`, `kanji`, or `vocabulary`.
 	 */
 	subject_types?: WKSubjectTuple;
-
-	/**
-	 * Only study material records updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
 }
 
 /**

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -127,11 +127,6 @@ export interface WKStudyMaterialParameters extends WKCollectionParameters {
 	hidden?: boolean;
 
 	/**
-	 * Only study material records where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Only study material records where `data.subject_id` matches one of the array values are returned.
 	 */
 	subject_ids?: number[];

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -496,11 +496,6 @@ export interface WKSubjectParameters extends WKCollectionParameters {
 	 * Return subjects which are or are not hidden from the user-facing application.
 	 */
 	hidden?: boolean;
-
-	/**
-	 * Only subjects updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
 }
 
 /**

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -478,11 +478,6 @@ export interface WKSubjectMeaning {
  */
 export interface WKSubjectParameters extends WKCollectionParameters {
 	/**
-	 * Only subjects where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Return subjects of the specified types.
 	 */
 	types?: WKSubjectTuple;

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -73,11 +73,6 @@ export interface WKVoiceActorData {
  */
 export interface WKVoiceActorParameters extends WKCollectionParameters {
 	/**
-	 * Only `voice_actors` where `data.id` matches one of the array values are returned.
-	 */
-	ids?: number[];
-
-	/**
 	 * Only `voice_actors` updated after this time are returned.
 	 */
 	updated_after?: Date | WKDatableString;

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -71,9 +71,4 @@ export interface WKVoiceActorData {
  * @category Parameters
  * @category Voice Actors
  */
-export interface WKVoiceActorParameters extends WKCollectionParameters {
-	/**
-	 * Only `voice_actors` updated after this time are returned.
-	 */
-	updated_after?: Date | WKDatableString;
-}
+export type WKVoiceActorParameters = WKCollectionParameters;


### PR DESCRIPTION
# Description

This PR extracts the `id` and `updated_after` properties from all the parameter types, and places them in `WKCollectionParameters`. Because these properties are usable on all collection queries, it makes sense to place them in the singular type that others extend from.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
