### PR TITLE
Base: Specify absent error properties on Collections/Reports/Resources

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -122,6 +122,16 @@ export interface WKCollection {
 		| WKSubject[]
 		| WKVocabulary[]
 		| WKVoiceActor[];
+
+	/**
+	 * A collection will never have a `code` property.
+	 */
+	code?: never;
+
+	/**
+	 * A collection will never have an `error` property.
+	 */
+	error?: never;
 }
 
 /**
@@ -357,6 +367,16 @@ export interface WKReport {
 	 * The report's data, dependent on the particular report.
 	 */
 	data: WKSummaryData;
+
+	/**
+	 * A report will never have a `code` property.
+	 */
+	code?: never;
+
+	/**
+	 * A report will never have an `error` property.
+	 */
+	error?: never;
 }
 
 /**
@@ -408,6 +428,16 @@ export interface WKResource {
 		| WKUserData
 		| WKVocabularyData
 		| WKVoiceActorData;
+
+	/**
+	 * A resource will never have a `code` property.
+	 */
+	code?: never;
+
+	/**
+	 * A resource will never have an `error` property.
+	 */
+	error?: never;
 }
 
 /**


### PR DESCRIPTION
# Description

This PR adds the `error` and `code` properties as never occurring on the `WKCollection`, `WKReport`, and `WKResource` types. This is so that TypeScript knows that, when anticipating a union such as `WKUser | WKError`, that the absence of an `error` or `code` property means we can narrow down to just `WKUser` or whatever collection/report/resource that is in union with `WKError`.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
