### PR TITLE
Base: Add WKLevel Type and Type Guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.7.0",
+	"version": "0.8.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -2,6 +2,7 @@ import type {
 	WKCollection,
 	WKCollectionParameters,
 	WKDatableString,
+	WKLevel,
 	WKMaxLevels,
 	WKMaxSrsStages,
 	WKResource,
@@ -169,7 +170,7 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
 	 * Only assignments where the associated subject level matches one of the array values are returned. Valid values
 	 * range from `1` to `60`.
 	 */
-	levels?: Range<1, WKMaxLevels>[];
+	levels?: WKLevel[];
 
 	/**
 	 * Only assignments where `data.srs_stage` matches one of the array values are returned. Valid values range from `0`

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -1,3 +1,4 @@
+import type { Brand, Range } from "../internal/index.js";
 import type {
 	WKAssignment,
 	WKAssignmentData,
@@ -37,7 +38,6 @@ import type {
 	WKVoiceActorData,
 	WKVoiceActorParameters,
 } from "../v20170710.js";
-import type { Brand } from "../internal/index.js";
 
 /**
  * All known WaniKani API revisions, created when breaking changes are introduced to the WaniKani API.
@@ -226,6 +226,11 @@ export interface WKError {
 	 */
 	url?: never;
 }
+
+/**
+ * A number representing a level in WaniKani, from `1` to `60`
+ */
+export type WKLevel = Range<1, WKMaxLevels>;
 
 /**
  * The maximum batch size for lessons in the WaniKani app.
@@ -530,6 +535,43 @@ export function isWKDatableString(possibleWKDatableString: unknown): possibleWKD
 		return true;
 	}
 	return false;
+}
+
+/**
+ * A type guard to determine if a given item is a {@link WKLevel}.
+ *
+ * @param possibleWKLevel - An unknown item.
+ * @returns `true` if the item is a valid {@link WKLevel}, `false` if not.
+ * @category Base
+ */
+export function isWKLevel(possibleWKLevel: unknown): possibleWKLevel is WKLevel {
+	return (
+		typeof possibleWKLevel === "number" &&
+		Number.isInteger(possibleWKLevel) &&
+		possibleWKLevel >= 1 &&
+		possibleWKLevel <= WK_MAX_LEVELS
+	);
+}
+
+/**
+ * A type guard to determine if a given item is a {@link WKLevel} array.
+ *
+ * @param possibleWKLevelArray - An unknown item.
+ * @returns `true` if the item is a valid {@link WKLevel} array, `false` if not.
+ * @category Base
+ */
+export function isWKLevelArray(possibleWKLevelArray: unknown): possibleWKLevelArray is WKLevel[] {
+	if (!Array.isArray(possibleWKLevelArray)) {
+		return false;
+	}
+	if (possibleWKLevelArray.length === 0) {
+		return false;
+	}
+	const allNumbersAndAllIntegers = possibleWKLevelArray.every(Number.isInteger);
+	const allNumbersInRange = possibleWKLevelArray.every((value) => {
+		return value >= 1 && value <= WK_MAX_LEVELS;
+	});
+	return allNumbersAndAllIntegers && allNumbersInRange;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,8 @@ export {
 	WK_MIN_LESSON_BATCH_SIZE,
 	WK_MIN_LEVELS,
 	isWKDatableString,
+	isWKLevel,
+	isWKLevelArray,
 	stringifyParameters,
 } from "./v20170710.js";
 
@@ -31,6 +33,7 @@ export type {
 	WKKanjiCollection,
 	WKKanjiData,
 	WKKanjiReading,
+	WKLevel,
 	WKLevelProgression,
 	WKLevelProgressionCollection,
 	WKLevelProgressionData,

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -1,5 +1,4 @@
-import type { WKCollection, WKCollectionParameters, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
-import type { Range } from "../internal/index.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKLevel, WKResource } from "../v20170710.js";
 
 /**
  * Level progressions contain information about a user's progress through the WaniKani levels.
@@ -72,7 +71,7 @@ export interface WKLevelProgressionData {
 	/**
 	 * The level of the progression, with possible values from `1` to `60`.
 	 */
-	level: Range<1, WKMaxLevels>;
+	level: WKLevel;
 
 	/**
 	 * Timestamp, in ISO-8601 format, when the user passes at least 90% of the assignments with a type of `kanji`

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -1,5 +1,4 @@
-import type { WKCollection, WKCollectionParameters, WKDatableString, WKMaxLevels, WKResource } from "../v20170710.js";
-import type { Range } from "../internal/index.js";
+import type { WKCollection, WKCollectionParameters, WKDatableString, WKLevel, WKResource } from "../v20170710.js";
 
 /**
  * Users can reset their progress back to any level at or below their current level. When they reset to a particular
@@ -63,12 +62,12 @@ export interface WKResetData {
 	/**
 	 * The user's level before the reset, from `1` to `60`.
 	 */
-	original_level: Range<1, WKMaxLevels>;
+	original_level: WKLevel;
 
 	/**
 	 * The user's level after the reset, from `1` to `60`. It must be less than or equal to `original_level`.
 	 */
-	target_level: Range<1, WKMaxLevels>;
+	target_level: WKLevel;
 }
 
 /**

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -2,11 +2,10 @@ import type {
 	WKCollection,
 	WKCollectionParameters,
 	WKDatableString,
-	WKMaxLevels,
+	WKLevel,
 	WKResource,
 	WKSubjectTuple,
 } from "../v20170710.js";
-import type { Range } from "../internal/index.js";
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `radical`, `kanji`, and
@@ -431,7 +430,7 @@ export interface WKSubjectData {
 	/**
 	 * The level of the subject, from `1` to `60`.
 	 */
-	level: Range<1, WKMaxLevels>;
+	level: WKLevel;
 
 	/**
 	 * The subject's meaning mnemonic.
@@ -500,7 +499,7 @@ export interface WKSubjectParameters extends WKCollectionParameters {
 	/**
 	 * Return subjects at the specified levels.
 	 */
-	levels?: Range<1, WKMaxLevels>[];
+	levels?: WKLevel[];
 
 	/**
 	 * Return subjects which are or are not hidden from the user-facing application.

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -1,5 +1,6 @@
 import type {
 	WKDatableString,
+	WKLevel,
 	WKMaxLessonBatchSize,
 	WKMaxLevels,
 	WKMinLessonBatchSize,
@@ -51,7 +52,7 @@ export interface WKUserData {
 	/**
 	 * The current level of the user. This ignores subscription status.
 	 */
-	level: Range<1, WKMaxLevels>;
+	level: WKLevel;
 
 	/**
 	 * User settings specific to the WaniKani application.

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -7,6 +7,8 @@ export {
 	WK_MIN_LESSON_BATCH_SIZE,
 	WK_MIN_LEVELS,
 	isWKDatableString,
+	isWKLevel,
+	isWKLevelArray,
 	stringifyParameters,
 } from "./base/v20170710.js";
 
@@ -28,6 +30,7 @@ export type {
 	WKCollectionParameters,
 	WKDatableString,
 	WKError,
+	WKLevel,
 	WKMaxLessonBatchSize,
 	WKMaxLevels,
 	WKMaxSrsReviewStages,

--- a/tests/base/isWKLevel.test.ts
+++ b/tests/base/isWKLevel.test.ts
@@ -1,0 +1,40 @@
+import { isWKLevel } from "../../src/base/v20170710";
+
+it("Returns false on non-numbers", () => {
+	const obj = {
+		property1: "cheesecake",
+	};
+	const symbol = Symbol("foo");
+	const func = function () {
+		return true;
+	};
+	const bigInt = 0x0099ffn;
+	const string = "Hello world";
+	const array: number[] = [];
+
+	expect(isWKLevel(false)).toBe(false);
+	expect(isWKLevel(null)).toBe(false);
+	expect(isWKLevel(undefined)).toBe(false);
+	expect(isWKLevel(obj)).toBe(false);
+	expect(isWKLevel(symbol)).toBe(false);
+	expect(isWKLevel(func)).toBe(false);
+	expect(isWKLevel(bigInt)).toBe(false);
+	expect(isWKLevel(string)).toBe(false);
+	expect(isWKLevel(array)).toBe(false);
+});
+
+it("Returns false on numbers out of range", () => {
+	expect(isWKLevel(-1)).toBe(false);
+	expect(isWKLevel(0)).toBe(false);
+	expect(isWKLevel(61)).toBe(false);
+});
+
+it("Returns false on non-integers", () => {
+	expect(isWKLevel(4.2)).toBe(false);
+});
+
+it("Returns true on valid WaniKani Levels", () => {
+	for (let i = 1; i <= 60; i++) {
+		expect(isWKLevel(i)).toBe(true);
+	}
+});

--- a/tests/base/isWKLevelArray.test.ts
+++ b/tests/base/isWKLevelArray.test.ts
@@ -1,0 +1,58 @@
+import { isWKLevelArray } from "../../src/base/v20170710";
+import type { WKLevel } from "../../src/base/v20170710";
+
+it("Returns false on non-arrays", () => {
+	const obj = {
+		property1: "cheesecake",
+	};
+	const symbol = Symbol("foo");
+	const func = function () {
+		return true;
+	};
+	const number = 42;
+	const bigInt = 0x0099ffn;
+	const string = "Hello world";
+
+	expect(isWKLevelArray(false)).toBe(false);
+	expect(isWKLevelArray(null)).toBe(false);
+	expect(isWKLevelArray(undefined)).toBe(false);
+	expect(isWKLevelArray(obj)).toBe(false);
+	expect(isWKLevelArray(symbol)).toBe(false);
+	expect(isWKLevelArray(func)).toBe(false);
+	expect(isWKLevelArray(number)).toBe(false);
+	expect(isWKLevelArray(bigInt)).toBe(false);
+	expect(isWKLevelArray(string)).toBe(false);
+});
+
+it("Returns false on empty arrays", () => {
+	const emptyArray: WKLevel[] = [];
+	expect(isWKLevelArray(emptyArray)).toBe(false);
+});
+
+it("Returns false on non-numeric arrays", () => {
+	const stringArray = ["one", "two", "three"];
+	const arrayOfObjects = [
+		{
+			a: "one",
+		},
+		{ a: "two" },
+		{ a: 3 },
+	];
+	const mixedArray = [1, "two", { c: 3, d: "four" }];
+	expect(isWKLevelArray(stringArray)).toBe(false);
+	expect(isWKLevelArray(arrayOfObjects)).toBe(false);
+	expect(isWKLevelArray(mixedArray)).toBe(false);
+});
+
+it("Returns false if array contains numbers out of range", () => {
+	const outOfRangeArray = [-1, 0, 61];
+	expect(isWKLevelArray(outOfRangeArray)).toBe(false);
+});
+
+it("Returns true on array of valid WaniKani Levels", () => {
+	const levelArray = [
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31,
+		32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
+	];
+	expect(isWKLevelArray(levelArray)).toBe(true);
+});


### PR DESCRIPTION
# Description

This PR adds a new type -- `WKLevel` -- and a couple type guards alongside it.

## `WKLevel`

This type was added to better describe WaniKani levels, instead of just `Range<1,WKMaxLevels>`. It has replaced the latter on any `level` or `levels` properties across the library.

## Type Guards

We also added two new type guards to check calculated numbers and arrays of numbers to make sure they are valid WaniKani Levels.

Before the type guards...

```typescript
// Say you fetched the level from a WKUser
const userLevel = user.data.level; // This was a Range<1,WKMaxLevel>

// But you also might need the user's previous level, e.g. to fetch assignments available in lessons
const previousLevel = userLevel - 1; // This is a number, but could be an invalid level!

const parms: WKAssignmentParameters = {
  levels: [previousLevel, userLevel]; // TypeScript throws an error!
}
```

With the type guards...

```typescript
// Say you fetched the level from a WKUser
const userLevel = user.data.level; // This is a WKLevel
// But you also might need the user's previous level, e.g. to fetch assignments available in lessons
const previousLevel = userLevel - 1; // This is a number, but could be an invalid level!

const levels: WKLevel[] = [userLevel]; // It's a WKLevel[] -- so far so good...

if (isWKLevel(previousLevel)) {
  levels.push(previousLevel); // It's only added on if it's a whole number between 1 and 60.
}

const params: WKAssignmentParameters = {
  levels, // "Looks good to me!" - TypeScript
}

/* or... */

const bothLevels = [previousLevel, userLevel]; // So far a number[]
const singleLevel = [userLevel]; // Is a WKLevel[]

const parms: WKAssignmentParameters = {};

if (isWKLevelArray(bothLevels)) {
  parms.levels = bothLevels;
} else {
  parms.levels = singleLevel;
}
```

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
