### PR TITLE
Base: Add WKSrsStageNumber Type and Type Guards

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "0.8.0",
+	"version": "0.9.0",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -4,8 +4,8 @@ import type {
 	WKDatableString,
 	WKLevel,
 	WKMaxLevels,
-	WKMaxSrsStages,
 	WKResource,
+	WKSrsStageNumber,
 	WKSubjectTuple,
 	WKSubjectType,
 } from "../v20170710.js";
@@ -93,7 +93,7 @@ export interface WKAssignmentData {
 	 * The current SRS stage interval. The interval range is determined by the related subject's Spaced Repetition
 	 * System.
 	 */
-	srs_stage: Range<0, WKMaxSrsStages>;
+	srs_stage: WKSrsStageNumber;
 
 	/**
 	 * When the user completes the lesson for the related subject.
@@ -176,7 +176,7 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
 	 * Only assignments where `data.srs_stage` matches one of the array values are returned. Valid values range from `0`
 	 * to `9`.
 	 */
-	srs_stages?: Range<0, WKMaxSrsStages>[];
+	srs_stages?: WKSrsStageNumber[];
 
 	/**
 	 * When set to `true`, returns assignments that have a value in `data.started_at`. Returns assignments with a `null`

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -463,6 +463,13 @@ export type WKResourceType =
 	| "voice_actor";
 
 /**
+ * A valid WaniKani Spaced Repetition System (SRS) Stage Number, based on the known SRS' on WaniKani and its API.
+ *
+ * @category Base
+ */
+export type WKSrsStageNumber = Range<0, WKMaxSrsStages>;
+
+/**
  * A non-empty array of WaniKani subject types.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
@@ -570,6 +577,45 @@ export function isWKLevelArray(possibleWKLevelArray: unknown): possibleWKLevelAr
 	const allNumbersAndAllIntegers = possibleWKLevelArray.every(Number.isInteger);
 	const allNumbersInRange = possibleWKLevelArray.every((value) => {
 		return value >= 1 && value <= WK_MAX_LEVELS;
+	});
+	return allNumbersAndAllIntegers && allNumbersInRange;
+}
+
+/**
+ * A type guard to determine if a given item is a {@link WKSrsStageNumber}.
+ *
+ * @param possibleWKSrsStageNumber - An unknown item.
+ * @returns `true` if the item is a valid {@link WKSrsStageNumber}, `false` if not.
+ * @category Base
+ */
+export function isWKSrsStageNumber(possibleWKSrsStageNumber: unknown): possibleWKSrsStageNumber is WKSrsStageNumber {
+	return (
+		typeof possibleWKSrsStageNumber === "number" &&
+		Number.isInteger(possibleWKSrsStageNumber) &&
+		possibleWKSrsStageNumber >= 0 &&
+		possibleWKSrsStageNumber <= WK_MAX_SRS_STAGES
+	);
+}
+
+/**
+ * A type guard to determine if a given item is a {@link WKSrsStageNumber} array.
+ *
+ * @param possibleWKSrsStageNumberArray - An unknown item.
+ * @returns `true` if the item is a valid {@link WKSrsStageNumber} array, `false` if not.
+ * @category Base
+ */
+export function isWKSrsStageNumberArray(
+	possibleWKSrsStageNumberArray: unknown,
+): possibleWKSrsStageNumberArray is WKSrsStageNumber[] {
+	if (!Array.isArray(possibleWKSrsStageNumberArray)) {
+		return false;
+	}
+	if (possibleWKSrsStageNumberArray.length === 0) {
+		return false;
+	}
+	const allNumbersAndAllIntegers = possibleWKSrsStageNumberArray.every(Number.isInteger);
+	const allNumbersInRange = possibleWKSrsStageNumberArray.every((value) => {
+		return value >= 0 && value <= WK_MAX_SRS_STAGES;
 	});
 	return allNumbersAndAllIntegers && allNumbersInRange;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,8 @@ export {
 	isWKDatableString,
 	isWKLevel,
 	isWKLevelArray,
+	isWKSrsStageNumber,
+	isWKSrsStageNumberArray,
 	stringifyParameters,
 } from "./v20170710.js";
 
@@ -75,6 +77,7 @@ export type {
 	WKSpacedRepetitionSystemData,
 	WKSpacedRepetitionSystemParameters,
 	WKSpacedRepetitionSystemStage,
+	WKSrsStageNumber,
 	WKStartedAssignment,
 	WKStartedAssignmentData,
 	WKStudyMaterial,

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -1,4 +1,10 @@
-import type { WKCollection, WKCollectionParameters, WKDatableString, WKResource } from "../v20170710.js";
+import type {
+	WKCollection,
+	WKCollectionParameters,
+	WKDatableString,
+	WKResource,
+	WKSrsStageNumber,
+} from "../v20170710.js";
 
 /**
  * Available spaced repetition systems used for calculating `srs_stage` changes to Assignments and Reviews. Has
@@ -70,7 +76,7 @@ export interface WKSpacedRepetitionSystemData {
 	/**
 	 * `position` of the passing stage.
 	 */
-	passing_stage_position: number;
+	passing_stage_position: WKSrsStageNumber;
 
 	/**
 	 * A collection of stages.
@@ -80,12 +86,12 @@ export interface WKSpacedRepetitionSystemData {
 	/**
 	 * `position` of the starting stage.
 	 */
-	starting_stage_position: number;
+	starting_stage_position: WKSrsStageNumber;
 
 	/**
 	 * `position` of the unlocking stage.
 	 */
-	unlocking_stage_position: number;
+	unlocking_stage_position: WKSrsStageNumber;
 }
 
 /**
@@ -118,5 +124,5 @@ export interface WKSpacedRepetitionSystemStage {
 	/**
 	 * The position of the stage within the continuous order.
 	 */
-	position: number;
+	position: WKSrsStageNumber;
 }

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -9,6 +9,8 @@ export {
 	isWKDatableString,
 	isWKLevel,
 	isWKLevelArray,
+	isWKSrsStageNumber,
+	isWKSrsStageNumberArray,
 	stringifyParameters,
 } from "./base/v20170710.js";
 
@@ -42,6 +44,7 @@ export type {
 	WKReport,
 	WKResource,
 	WKResourceType,
+	WKSrsStageNumber,
 	WKSubjectTuple,
 	WKSubjectType,
 } from "./base/v20170710.js";

--- a/tests/base/isWKSrsNumber.test.ts
+++ b/tests/base/isWKSrsNumber.test.ts
@@ -1,0 +1,39 @@
+import { isWKSrsStageNumber } from "../../src/base/v20170710";
+
+it("Returns false on non-numbers", () => {
+	const obj = {
+		property1: "cheesecake",
+	};
+	const symbol = Symbol("foo");
+	const func = function () {
+		return true;
+	};
+	const bigInt = 0x0099ffn;
+	const string = "Hello world";
+	const array: number[] = [];
+
+	expect(isWKSrsStageNumber(false)).toBe(false);
+	expect(isWKSrsStageNumber(null)).toBe(false);
+	expect(isWKSrsStageNumber(undefined)).toBe(false);
+	expect(isWKSrsStageNumber(obj)).toBe(false);
+	expect(isWKSrsStageNumber(symbol)).toBe(false);
+	expect(isWKSrsStageNumber(func)).toBe(false);
+	expect(isWKSrsStageNumber(bigInt)).toBe(false);
+	expect(isWKSrsStageNumber(string)).toBe(false);
+	expect(isWKSrsStageNumber(array)).toBe(false);
+});
+
+it("Returns false on numbers out of range", () => {
+	expect(isWKSrsStageNumber(-1)).toBe(false);
+	expect(isWKSrsStageNumber(10)).toBe(false);
+});
+
+it("Returns false on non-integers", () => {
+	expect(isWKSrsStageNumber(4.2)).toBe(false);
+});
+
+it("Returns true on valid WaniKani SRS Stage numbers", () => {
+	for (let i = 0; i <= 9; i++) {
+		expect(isWKSrsStageNumber(i)).toBe(true);
+	}
+});

--- a/tests/base/isWKSrsStageNumberArray.test.ts
+++ b/tests/base/isWKSrsStageNumberArray.test.ts
@@ -1,0 +1,55 @@
+import { isWKSrsStageNumberArray } from "../../src/base/v20170710";
+import type { WKSrsStageNumber } from "../../src/base/v20170710";
+
+it("Returns false on non-arrays", () => {
+	const obj = {
+		property1: "cheesecake",
+	};
+	const symbol = Symbol("foo");
+	const func = function () {
+		return true;
+	};
+	const number = 42;
+	const bigInt = 0x0099ffn;
+	const string = "Hello world";
+
+	expect(isWKSrsStageNumberArray(false)).toBe(false);
+	expect(isWKSrsStageNumberArray(null)).toBe(false);
+	expect(isWKSrsStageNumberArray(undefined)).toBe(false);
+	expect(isWKSrsStageNumberArray(obj)).toBe(false);
+	expect(isWKSrsStageNumberArray(symbol)).toBe(false);
+	expect(isWKSrsStageNumberArray(func)).toBe(false);
+	expect(isWKSrsStageNumberArray(number)).toBe(false);
+	expect(isWKSrsStageNumberArray(bigInt)).toBe(false);
+	expect(isWKSrsStageNumberArray(string)).toBe(false);
+});
+
+it("Returns false on empty arrays", () => {
+	const emptyArray: WKSrsStageNumber[] = [];
+	expect(isWKSrsStageNumberArray(emptyArray)).toBe(false);
+});
+
+it("Returns false on non-numeric arrays", () => {
+	const stringArray = ["one", "two", "three"];
+	const arrayOfObjects = [
+		{
+			a: "one",
+		},
+		{ a: "two" },
+		{ a: 3 },
+	];
+	const mixedArray = [1, "two", { c: 3, d: "four" }];
+	expect(isWKSrsStageNumberArray(stringArray)).toBe(false);
+	expect(isWKSrsStageNumberArray(arrayOfObjects)).toBe(false);
+	expect(isWKSrsStageNumberArray(mixedArray)).toBe(false);
+});
+
+it("Returns false if array contains numbers out of range", () => {
+	const outOfRangeArray = [-1, 10];
+	expect(isWKSrsStageNumberArray(outOfRangeArray)).toBe(false);
+});
+
+it("Returns true on array of valid WaniKani SRS Stage numbers", () => {
+	const srsStageArray = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+	expect(isWKSrsStageNumberArray(srsStageArray)).toBe(true);
+});


### PR DESCRIPTION
# Description

This PR adds a `WKSrsStageNumber` type and some type guards. See #47 for similar reasoning.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
