### PR TITLE
Renovate: Better TypeScript Update Names

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -18,7 +18,7 @@
 			"matchPackageNames": ["typescript"],
 			"matchUpdateTypes": ["patch"],
 			"labels": ["typescript"],
-			"groupName": "TypeScript",
+			"groupName": "TypeScript Development Version",
 			"automerge": true,
 			"platformAutomerge": true
 		},
@@ -26,14 +26,14 @@
 			"matchPackageNames": ["typescript"],
 			"matchUpdateTypes": ["major", "minor"],
 			"labels": ["typescript"],
-			"groupName": "TypeScript",
+			"groupName": "TypeScript Development Version",
 			"dependencyDashboardApproval": true
 		},
 		{
 			"matchPackageNames": ["typescript"],
 			"matchDepTypes": ["peerDependencies"],
 			"labels": ["typescript"],
-			"groupName": "TypeScript",
+			"groupName": "Supported TypeScript Versions",
 			"dependencyDashboardApproval": true
 		}
 	]


### PR DESCRIPTION
# Description

This PR tells Renovate (the bot that manages this library's dependencies) to use more descriptive group names for TypeScript depending on the type of update. This will make it clearer in the release notes what kind of TypeScript-related change was done.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
