### PR TITLE
Tests: Use Jest Globals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "MIT",
 			"devDependencies": {
 				"@bachmacintosh/typedoc-theme": "0.1.2",
-				"@types/jest": "29.2.2",
+				"@jest/globals": "29.3.1",
 				"@typescript-eslint/eslint-plugin": "5.42.1",
 				"@typescript-eslint/parser": "5.42.1",
 				"eslint": "8.27.0",
@@ -1266,16 +1266,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"node_modules/@types/jest": {
-			"version": "29.2.2",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.2.tgz",
-			"integrity": "sha512-og1wAmdxKoS71K2ZwSVqWPX6OVn3ihZ6ZT2qvZvZQm90lJVDyXIjYcu4Khx2CNIeaFv12rOU/YObOsI3VOkzog==",
-			"dev": true,
-			"dependencies": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
 			}
 		},
 		"node_modules/@types/json-schema": {
@@ -5797,16 +5787,6 @@
 			"dev": true,
 			"requires": {
 				"@types/istanbul-lib-report": "*"
-			}
-		},
-		"@types/jest": {
-			"version": "29.2.2",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.2.2.tgz",
-			"integrity": "sha512-og1wAmdxKoS71K2ZwSVqWPX6OVn3ihZ6ZT2qvZvZQm90lJVDyXIjYcu4Khx2CNIeaFv12rOU/YObOsI3VOkzog==",
-			"dev": true,
-			"requires": {
-				"expect": "^29.0.0",
-				"pretty-format": "^29.0.0"
 			}
 		},
 		"@types/json-schema": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 	},
 	"devDependencies": {
 		"@bachmacintosh/typedoc-theme": "0.1.2",
-		"@types/jest": "29.2.2",
+		"@jest/globals": "29.3.1",
 		"@typescript-eslint/eslint-plugin": "5.42.1",
 		"@typescript-eslint/parser": "5.42.1",
 		"eslint": "8.27.0",

--- a/tests/base/isWKDatableString.test.ts
+++ b/tests/base/isWKDatableString.test.ts
@@ -1,4 +1,4 @@
-import { expect, jest, test } from "@jest/globals";
+import { expect, it } from "@jest/globals";
 import { isWKDatableString } from "../../src/base/v20170710";
 
 it("Returns false on non-strings", () => {

--- a/tests/base/isWKLessonBatchSizeNumber.test.ts
+++ b/tests/base/isWKLessonBatchSizeNumber.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { isWKLessonBatchSizeNumber } from "../../src/base/v20170710";
 
 it("Returns false on non-numbers", () => {

--- a/tests/base/isWKLevel.test.ts
+++ b/tests/base/isWKLevel.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { isWKLevel } from "../../src/base/v20170710";
 
 it("Returns false on non-numbers", () => {

--- a/tests/base/isWKLevelArray.test.ts
+++ b/tests/base/isWKLevelArray.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { isWKLevelArray } from "../../src/base/v20170710";
 import type { WKLevel } from "../../src/base/v20170710";
 

--- a/tests/base/isWKSrsNumber.test.ts
+++ b/tests/base/isWKSrsNumber.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { isWKSrsStageNumber } from "../../src/base/v20170710";
 
 it("Returns false on non-numbers", () => {

--- a/tests/base/isWKSrsStageNumberArray.test.ts
+++ b/tests/base/isWKSrsStageNumberArray.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { isWKSrsStageNumberArray } from "../../src/base/v20170710";
 import type { WKSrsStageNumber } from "../../src/base/v20170710";
 

--- a/tests/base/stringifyParameters.test.ts
+++ b/tests/base/stringifyParameters.test.ts
@@ -1,3 +1,4 @@
+import { expect, it } from "@jest/globals";
 import { stringifyParameters } from "../../src/base/v20170710";
 import type { WKAssignmentParameters } from "../../src/assignments/v20170710";
 import type { WKDatableString } from "../../src/base/v20170710";


### PR DESCRIPTION
# Description

This PR swaps out the `@types/jest` dependency in favor of using `@jest/globals` directly. This ensures that Jest's typings are more up to date and in line with our current version.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

Tests have been updated only, no library changes.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>