### PR TITLE
User: Mark wanikani_compatibility_mode as Deprecated

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "1.0.0-rc1",
+	"version": "1.0.0-rc2",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -129,6 +129,9 @@ export interface WKUserPreferences {
 
 	/**
 	 * Whether or not the user has enabled Script Compatibility Mode in the WaniKani app.
+	 *
+	 * @deprecated WaniKani is retiring Script Compatibility Mode in the near future, and this property may be removed
+	 * from the `/user` endpoint (and this library). Avoid using in new applications.
 	 */
 	wanikani_compatibility_mode: boolean;
 }


### PR DESCRIPTION
# Description

This PR marks the `wanikani_compatibility_mode` property under `WKUserPreferences` as deprecated, in response to the [announcement posted in the WaniKani Community Forums](https://community.wanikani.com/t/we-are-starting-to-retire-script-compatibility-mode/59285?u=bachmac) about retiring Script Compatibility Mode.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>