### PR TITLE
Docs: Update README with Deno NPM Specifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,34 @@ import type { WKAssignmentParameters, WKDatableString } from "@bachmacintosh/wan
 import { stringifyParameters } from "@bachmacintosh/wanikani-api-types";
 ```
 
-### Deno and Other Environments
+### Deno via NPM Specifier
+
+Deno version 1.28 and up can import the library using an [npm specifier](https://deno.land/manual@v1.28.1/node/npm_specifiers).
+
+**Be sure to replace `x.y.z` with your desired version number.**
+
+#### Specific API Revision (Recommended)
+
+The module you import from matches a [WaniKani API Revision](https://docs.api.wanikani.com/20170710/#revisions-aka-versioning); you shouldn't expect any breaking changes from the package.
+
+```typescript
+import type {
+  WKAssignmentParameters,
+  WKDatableString,
+} from "npm:@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710";
+import { stringifyParameters } from "npm:@bachmacintosh/wanikani-api-types@x.y.z/dist/v20170710";
+```
+
+#### Latest API Revision (Not Recommended)
+
+Importing from the index module will always provide types, methods, etc. for use with the latest and greatest API Revision.
+
+```typescript
+import type { WKAssignmentParameters, WKDatableString } from "npm:@bachmacintosh/wanikani-api-types@x.y.z";
+import { stringifyParameters } from "npm:@bachmacintosh/wanikani-api-types@x.y.z";
+```
+
+### Other Environments
 
 You can import the modules directly with `esm.sh`.
 


### PR DESCRIPTION
# Description

Deno 1.28 introduced NPM Specifiers which allow imports from the NPM Registry. I've updated the README to include this as a usage option.

# Related Issue(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
