### PR TITLE
Base: Check for Leap Years in isWKDatableString()

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -3,4 +3,16 @@
 module.exports = {
 	preset: "ts-jest",
 	testEnvironment: "node",
+	extensionsToTreatAsEsm: [".ts"],
+	transform: {
+		"^.+\\.[tj]sx?$": [
+			"ts-jest",
+			{
+				useESM: true,
+			},
+		],
+	},
+	moduleNameMapper: {
+		"^(\\.{1,2}/.*)\\.js$": "$1",
+	},
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@bachmacintosh/wanikani-api-types",
-	"version": "1.0.0-rc3",
+	"version": "1.0.0-rc4",
 	"description": "Regularly updated type definitions for the WaniKani API",
 	"keywords": [
 		"wanikani",

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -27,6 +27,7 @@ import type {
 	WKVoiceActor,
 	WKVoiceActorData,
 } from "../v20170710.js";
+import { isValidDate } from "../internal/index.js";
 
 /**
  * All known WaniKani API revisions, created when breaking changes are introduced to the WaniKani API.
@@ -464,12 +465,6 @@ export type WKSubjectType = "kanji" | "radical" | "vocabulary";
  * @category Base
  */
 export function isWKDatableString(possibleWKDatableString: unknown): possibleWKDatableString is WKDatableString {
-	const monthsInYear = 12;
-	const thirtyDays = 30;
-	const thirtyOneDays = 31;
-	const monthsWithThirtyDays = ["04", "06", "09", "11"];
-	const monthsWithThirtyOneDays = ["01", "03", "05", "07", "08", "10", "12"];
-	const february = 2;
 	const twentyFourHours = 24;
 
 	const datePattern =
@@ -479,19 +474,11 @@ export function isWKDatableString(possibleWKDatableString: unknown): possibleWKD
 		if (matches === null || typeof matches.groups === "undefined") {
 			return false;
 		}
+		const yearNumber = parseInt(matches.groups.year, 10);
 		const monthNumber = parseInt(matches.groups.month, 10);
 		const dayNumber = parseInt(matches.groups.day, 10);
 		const hourNumber = parseInt(matches.groups.hour, 10);
-		if (monthNumber > monthsInYear) {
-			return false;
-		}
-		if (monthsWithThirtyDays.includes(matches.groups.month) && dayNumber > thirtyDays) {
-			return false;
-		}
-		if (monthsWithThirtyOneDays.includes(matches.groups.month) && dayNumber > thirtyOneDays) {
-			return false;
-		}
-		if (monthNumber === february && dayNumber >= thirtyDays) {
+		if (!isValidDate(yearNumber, monthNumber, dayNumber)) {
 			return false;
 		}
 		if (hourNumber >= twentyFourHours) {

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -37,3 +37,60 @@ export type Nullable<T> = { [K in keyof T]: Nullable<T[K]> | null };
  */
 
 export type Range<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>> | T;
+
+/**
+ * Checks if a given year, month, and day compose a valid date.
+ *
+ * @param year - A year number
+ * @param month - A month number
+ * @param day  - A day number
+ * @returns `true` if the year, month, and day are a valid date, `false` if not.
+ * @internal
+ */
+export function isValidDate(year: number, month: number, day: number): boolean {
+	const fourYears = 4;
+	const oneHundredYears = 100;
+	const fourHundredYears = 400;
+	const isLeapYear = (year % fourYears === 0 && year % oneHundredYears !== 0) || year % fourHundredYears === 0;
+	const monthsInYear = 12;
+	const thirtyOneDays = 31;
+	const thirtyDays = 30;
+	const twentyNineDays = 29;
+	const months = {
+		january: 1,
+		february: 2,
+		march: 3,
+		april: 4,
+		may: 5,
+		june: 6,
+		july: 7,
+		august: 8,
+		september: 9,
+		october: 10,
+		november: 11,
+		december: 12,
+	};
+	const monthsWithThirtyDays = [months.april, months.june, months.september, months.november];
+	const monthsWithThirtyOneDays = [
+		months.january,
+		months.march,
+		months.may,
+		months.july,
+		months.august,
+		months.october,
+		months.december,
+	];
+	if (month > monthsInYear) {
+		return false;
+	}
+	if (monthsWithThirtyOneDays.includes(month) && day > thirtyOneDays) {
+		return false;
+	}
+	if (monthsWithThirtyDays.includes(month) && day > thirtyDays) {
+		return false;
+	}
+	if (month === months.february && ((isLeapYear && day >= thirtyDays) || (!isLeapYear && day >= twentyNineDays))) {
+		return false;
+	}
+	return true;
+}

--- a/tests/base/isWKDatableString.test.ts
+++ b/tests/base/isWKDatableString.test.ts
@@ -27,6 +27,7 @@ it("Returns false on invalid/incomplete date-time strings", () => {
 	const stringWithOnlyDate = "2022-10-31";
 	const stringWithBadYear = "800-10-31T12:00:00.000000Z";
 	const stringWithBadMonth = "2022-13-31T12:00:00.000000Z";
+	const stringWithBadLeapDay = "2021-02-29T12:00:00.000000Z";
 	const stringsWithBadDays = [
 		"2022-10-32T12:00:00.000000Z",
 		"2022-09-31T12:00:00.000000Z",
@@ -45,6 +46,7 @@ it("Returns false on invalid/incomplete date-time strings", () => {
 	expect(isWKDatableString(stringWithOnlyDate)).toBe(false);
 	expect(isWKDatableString(stringWithBadYear)).toBe(false);
 	expect(isWKDatableString(stringWithBadMonth)).toBe(false);
+	expect(isWKDatableString(stringWithBadLeapDay)).toBe(false);
 	stringsWithBadDays.forEach((month) => {
 		expect(isWKDatableString(month)).toBe(false);
 	});
@@ -61,10 +63,12 @@ it("Returns false on invalid/incomplete date-time strings", () => {
 it("Returns true on valid ISO-8601 date-time strings", () => {
 	const dateTimeUtcString = "2022-10-23T15:17:38.828455Z";
 	const dateTimeOffsetString = "2022-10-23T15:17:38.828455+09:00";
+	const validLeapYear = "2020-02-29T12:00:00.000000Z";
 	const date = new Date();
 	const dateIsoString = date.toISOString();
 
 	expect(isWKDatableString(dateTimeUtcString)).toBe(true);
 	expect(isWKDatableString(dateTimeOffsetString)).toBe(true);
 	expect(isWKDatableString(dateIsoString)).toBe(true);
+	expect(isWKDatableString(validLeapYear)).toBe(true);
 });


### PR DESCRIPTION
# Description

This PR updates the `isWKDatableString()` type guard by having it check for leap years, not just if a date from February has 30 or more days.

The date validation logic has been extracted to an internal function `isValidDate()` due to the parent function becoming [too cyclomatically complex](https://eslint.org/docs/latest/rules/complexity).

We also took care of a quick chore in the Jest config to better support ES Modules; this was needed to properly resolve the imported `isValidDate()` function in Jest.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
