### PR TITLE
Base: Remove WKSubjectData from WKResource Data Prop

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -19,7 +19,6 @@ import type {
 	WKStudyMaterial,
 	WKStudyMaterialData,
 	WKSubject,
-	WKSubjectData,
 	WKSummaryData,
 	WKUserData,
 	WKVocabulary,
@@ -399,7 +398,6 @@ export interface WKResource {
 		| WKReviewStatisticData
 		| WKSpacedRepetitionSystemData
 		| WKStudyMaterialData
-		| WKSubjectData
 		| WKUserData
 		| WKVocabularyData
 		| WKVoiceActorData;


### PR DESCRIPTION
# Description

Thisd PR updates the `data` property under `WKResource`, and removes `WKSubjectData` from the union. This was from when `WKSubjectData` was a union of all radical/kanji/vocabulary data instead of its current form is a base type for the 3 subject types.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin@bachman.io>
