### PR TITLE
Subjects: Markup Matchers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export {
 	WK_MAX_SRS_STAGES,
 	WK_MIN_LESSON_BATCH_SIZE,
 	WK_MIN_LEVELS,
+	WK_SUBJECT_MARKUP_MATCHERS,
 	isWKDatableString,
 	isWKLessonBatchSizeNumber,
 	isWKLevel,

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -463,32 +463,32 @@ export interface WKSubjectData {
  */
 export const WK_SUBJECT_MARKUP_MATCHERS = {
 	/**
-	 * A regular expression literal that matches to Japanese text surrounded by <ja> tags.
+	 * A regular expression literal that matches to Japanese text surrounded by `<ja>` tags.
 	 */
 	ja: /<ja>(?<innerText>.+?)<\/ja>/gu,
 
 	/**
-	 * A regular expression literal that matches to Japanese kanji surrounded by <kanji> tags.
+	 * A regular expression literal that matches to Japanese kanji surrounded by `<kanji>` tags.
 	 */
 	kanji: /<kanji>(?<innerText>.+?)<\/kanji>/gu,
 
 	/**
-	 * A regular expression literal that matches to a subject meaning surrounded by <meaning> tags.
+	 * A regular expression literal that matches to a subject meaning surrounded by `<meaning>` tags.
 	 */
 	meaning: /<meaning>(?<innerText>.+?)<\/meaning>/gu,
 
 	/**
-	 * A regular expression literal that matches to WaniKani Radical names surrounded by <radical> tags.
+	 * A regular expression literal that matches to WaniKani Radical names surrounded by `<radical>` tags.
 	 */
 	radical: /<radical>(?<innerText>.+?)<\/radical>/gu,
 
 	/**
-	 * A regular expression literal that matches to a kanji/vocabulary reading surrounded by <reading> tags.
+	 * A regular expression literal that matches to a kanji/vocabulary reading surrounded by `<reading>` tags.
 	 */
 	reading: /<reading>(?<innerText>.+?)<\/reading>/gu,
 
 	/**
-	 * A regular expression literal that matches to WaniKani Vocabulary surrounded by <vocabulary> tags.
+	 * A regular expression literal that matches to WaniKani Vocabulary surrounded by `<vocabulary>` tags.
 	 */
 	vocabulary: /<vocabulary>(?<innerText>.+?)<\/vocabulary>/gu,
 } as const;

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -454,6 +454,15 @@ export interface WKSubjectData {
 	spaced_repetition_system_id: number;
 }
 
+export const WK_SUBJECT_MARKUP_MATCHERS = {
+	ja: /<ja>(?<innerText>.+?)<\/ja>/gu,
+	kanji: /<kanji>(?<innerText>.+?)<\/kanji>/gu,
+	meaning: /<meaning>(?<innerText>.+?)<\/meaning>/gu,
+	radical: /<radical>(?<innerText>.+?)<\/radical>/gu,
+	reading: /<reading>(?<innerText>.+?)<\/reading>/gu,
+	vocabulary: /<vocabulary>(?<innerText>.+?)<\/vocabulary>/gu,
+} as const;
+
 /**
  * Information pertaining to a subject's meaning.
  *

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -454,12 +454,42 @@ export interface WKSubjectData {
 	spaced_repetition_system_id: number;
 }
 
+/**
+ * A set of regular expression literals that match to various markup patterns in a Subject's Meaning/Reading Mnemonics
+ * and Hints.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Subjects
+ */
 export const WK_SUBJECT_MARKUP_MATCHERS = {
+	/**
+	 * A regular expression literal that matches to Japanese text surrounded by <ja> tags.
+	 */
 	ja: /<ja>(?<innerText>.+?)<\/ja>/gu,
+
+	/**
+	 * A regular expression literal that matches to Japanese kanji surrounded by <kanji> tags.
+	 */
 	kanji: /<kanji>(?<innerText>.+?)<\/kanji>/gu,
+
+	/**
+	 * A regular expression literal that matches to a subject meaning surrounded by <meaning> tags.
+	 */
 	meaning: /<meaning>(?<innerText>.+?)<\/meaning>/gu,
+
+	/**
+	 * A regular expression literal that matches to WaniKani Radical names surrounded by <radical> tags.
+	 */
 	radical: /<radical>(?<innerText>.+?)<\/radical>/gu,
+
+	/**
+	 * A regular expression literal that matches to a kanji/vocabulary reading surrounded by <reading> tags.
+	 */
 	reading: /<reading>(?<innerText>.+?)<\/reading>/gu,
+
+	/**
+	 * A regular expression literal that matches to WaniKani Vocabulary surrounded by <vocabulary> tags.
+	 */
 	vocabulary: /<vocabulary>(?<innerText>.+?)<\/vocabulary>/gu,
 } as const;
 

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -15,6 +15,8 @@ export {
 	stringifyParameters,
 } from "./base/v20170710.js";
 
+export { WK_SUBJECT_MARKUP_MATCHERS } from "./subjects/v20170710.js";
+
 export type {
 	WKAssignment,
 	WKAssignmentCollection,

--- a/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
+++ b/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
@@ -1,0 +1,62 @@
+import { expect, it } from "@jest/globals";
+import { WK_SUBJECT_MARKUP_MATCHERS } from "../../src/subjects/v20170710.js";
+
+it("Matches Japanese text highlighting in <ja> tags", () => {
+	const testString = `The romaji "ka" can be written as <ja>か</ja> in hiragana. The romaji "setsu" can be written as <ja>せつ</ja>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.ja)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<ja>か</ja>");
+	expect(matchedJa[0].groups?.innerText).toBe("か");
+	expect(matchedJa[1][0]).toBe("<ja>せつ</ja>");
+	expect(matchedJa[1].groups?.innerText).toBe("せつ");
+});
+
+it("Matches Kanji highlighting in <kanji> tags", () => {
+	const testString = `Two of WaniKani's Level 1 Kanji are <kanji>山</kanji> and <kanji>人</kanji>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.kanji)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<kanji>山</kanji>");
+	expect(matchedJa[0].groups?.innerText).toBe("山");
+	expect(matchedJa[1][0]).toBe("<kanji>人</kanji>");
+	expect(matchedJa[1].groups?.innerText).toBe("人");
+});
+
+it("Matches Meaning highlighting in <meaning> tags", () => {
+	const testString = `The kanji 一 means <meaning>one</meaning>. The kanji 二 means <meaning>two</meaning>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.meaning)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<meaning>one</meaning>");
+	expect(matchedJa[0].groups?.innerText).toBe("one");
+	expect(matchedJa[1][0]).toBe("<meaning>two</meaning>");
+	expect(matchedJa[1].groups?.innerText).toBe("two");
+});
+
+it("Matches Radical highlighting in <radical> tags", () => {
+	const testString = `One of the first radicals is the <radical>ground</radical> radical. A more complex one is <radical>coat rack</radical>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.radical)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<radical>ground</radical>");
+	expect(matchedJa[0].groups?.innerText).toBe("ground");
+	expect(matchedJa[1][0]).toBe("<radical>coat rack</radical>");
+	expect(matchedJa[1].groups?.innerText).toBe("coat rack");
+});
+
+it("Matches Reading highlighting in <reading> tags", () => {
+	const testString = `The partical は can sound like <reading>ha</reading>, but is also read like <reading>wa</reading>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.reading)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<reading>ha</reading>");
+	expect(matchedJa[0].groups?.innerText).toBe("ha");
+	expect(matchedJa[1][0]).toBe("<reading>wa</reading>");
+	expect(matchedJa[1].groups?.innerText).toBe("wa");
+});
+
+it("Matches Vocabulary highlighting in <vocabulary> tags", () => {
+	const testString = `The kanji 一 is used in the vocabulary <vocabulary>one thing</vocabulary> and <vocabulary>first floor</vocabulary>.`;
+	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
+	expect(matchedJa).toHaveLength(2);
+	expect(matchedJa[0][0]).toBe("<vocabulary>one thing</vocabulary>");
+	expect(matchedJa[0].groups?.innerText).toBe("one thing");
+	expect(matchedJa[1][0]).toBe("<vocabulary>first floor</vocabulary>");
+	expect(matchedJa[1].groups?.innerText).toBe("first floor");
+});

--- a/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
+++ b/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
@@ -13,50 +13,50 @@ it("Matches Japanese text highlighting in <ja> tags", () => {
 
 it("Matches Kanji highlighting in <kanji> tags", () => {
 	const testString = `Two of WaniKani's Level 1 Kanji are <kanji>山</kanji> and <kanji>人</kanji>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.kanji)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<kanji>山</kanji>");
-	expect(matchedJa[0].groups?.innerText).toBe("山");
-	expect(matchedJa[1][0]).toBe("<kanji>人</kanji>");
-	expect(matchedJa[1].groups?.innerText).toBe("人");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.kanji)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<kanji>山</kanji>");
+	expect(matchedText[0].groups?.innerText).toBe("山");
+	expect(matchedText[1][0]).toBe("<kanji>人</kanji>");
+	expect(matchedText[1].groups?.innerText).toBe("人");
 });
 
 it("Matches Meaning highlighting in <meaning> tags", () => {
 	const testString = `The kanji 一 means <meaning>one</meaning>. The kanji 二 means <meaning>two</meaning>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.meaning)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<meaning>one</meaning>");
-	expect(matchedJa[0].groups?.innerText).toBe("one");
-	expect(matchedJa[1][0]).toBe("<meaning>two</meaning>");
-	expect(matchedJa[1].groups?.innerText).toBe("two");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.meaning)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<meaning>one</meaning>");
+	expect(matchedText[0].groups?.innerText).toBe("one");
+	expect(matchedText[1][0]).toBe("<meaning>two</meaning>");
+	expect(matchedText[1].groups?.innerText).toBe("two");
 });
 
 it("Matches Radical highlighting in <radical> tags", () => {
 	const testString = `One of the first radicals is the <radical>ground</radical> radical. A more complex one is <radical>coat rack</radical>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.radical)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<radical>ground</radical>");
-	expect(matchedJa[0].groups?.innerText).toBe("ground");
-	expect(matchedJa[1][0]).toBe("<radical>coat rack</radical>");
-	expect(matchedJa[1].groups?.innerText).toBe("coat rack");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.radical)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<radical>ground</radical>");
+	expect(matchedText[0].groups?.innerText).toBe("ground");
+	expect(matchedText[1][0]).toBe("<radical>coat rack</radical>");
+	expect(matchedText[1].groups?.innerText).toBe("coat rack");
 });
 
 it("Matches Reading highlighting in <reading> tags", () => {
 	const testString = `The partical は can sound like <reading>ha</reading>, but is also read like <reading>wa</reading>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.reading)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<reading>ha</reading>");
-	expect(matchedJa[0].groups?.innerText).toBe("ha");
-	expect(matchedJa[1][0]).toBe("<reading>wa</reading>");
-	expect(matchedJa[1].groups?.innerText).toBe("wa");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.reading)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<reading>ha</reading>");
+	expect(matchedText[0].groups?.innerText).toBe("ha");
+	expect(matchedText[1][0]).toBe("<reading>wa</reading>");
+	expect(matchedText[1].groups?.innerText).toBe("wa");
 });
 
 it("Matches Vocabulary highlighting in <vocabulary> tags", () => {
 	const testString = `The kanji 一 is used in the vocabulary <vocabulary>one thing</vocabulary> and <vocabulary>first floor</vocabulary>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<vocabulary>one thing</vocabulary>");
-	expect(matchedJa[0].groups?.innerText).toBe("one thing");
-	expect(matchedJa[1][0]).toBe("<vocabulary>first floor</vocabulary>");
-	expect(matchedJa[1].groups?.innerText).toBe("first floor");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<vocabulary>one thing</vocabulary>");
+	expect(matchedText[0].groups?.innerText).toBe("one thing");
+	expect(matchedText[1][0]).toBe("<vocabulary>first floor</vocabulary>");
+	expect(matchedText[1].groups?.innerText).toBe("first floor");
 });

--- a/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
+++ b/tests/subjects/WK_SUBJECT_MARKUP_PATTERNS.test.ts
@@ -3,12 +3,12 @@ import { WK_SUBJECT_MARKUP_MATCHERS } from "../../src/subjects/v20170710.js";
 
 it("Matches Japanese text highlighting in <ja> tags", () => {
 	const testString = `The romaji "ka" can be written as <ja>か</ja> in hiragana. The romaji "setsu" can be written as <ja>せつ</ja>.`;
-	const matchedJa = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.ja)];
-	expect(matchedJa).toHaveLength(2);
-	expect(matchedJa[0][0]).toBe("<ja>か</ja>");
-	expect(matchedJa[0].groups?.innerText).toBe("か");
-	expect(matchedJa[1][0]).toBe("<ja>せつ</ja>");
-	expect(matchedJa[1].groups?.innerText).toBe("せつ");
+	const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.ja)];
+	expect(matchedText).toHaveLength(2);
+	expect(matchedText[0][0]).toBe("<ja>か</ja>");
+	expect(matchedText[0].groups?.innerText).toBe("か");
+	expect(matchedText[1][0]).toBe("<ja>せつ</ja>");
+	expect(matchedText[1].groups?.innerText).toBe("せつ");
 });
 
 it("Matches Kanji highlighting in <kanji> tags", () => {


### PR DESCRIPTION
# Description

This PR will add Regex Literals corresponding to the Markup Highlighting found in WaniKani's Subject Mnemonics and Hints. They can be used to extract/replace/format/etc. the markup for a cleaner presentation when displaying said Mnemonics/Hints.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

For example, used in a React app:

```tsx
import { WK_SUBJECT_MARKUP_MATCHERS } from "@bachmacintosh/wanikani-api-types/dist/v20170710";
import reactStringReplace from "react-string-replace";

reactStringReplace('The <radical>ground</radical> moves under my feet.', WK_SUBJECT_MARKUP_MATCHERS.radical, (match, i) => (
  <span>{match}</span>
));
// => [ 'The ', <span>ground</span>, ' moves under my feet.' ]
```

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)

Signed-off-by: Collin Bachman <collin.r68zdn9d@bachman.dev>
