### PR TITLE
Chore: Rename validatePayloads to validatePayload

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -837,7 +837,7 @@ export function validateParameters<T extends keyof WKCollectionParametersMap>(
  * @category Base
  * @category Payloads
  */
-export function validatePayloads<T extends keyof WKPayloadMap>(type: T, payload: WKPayloadMap[T]): void {
+export function validatePayload<T extends keyof WKPayloadMap>(type: T, payload: WKPayloadMap[T]): void {
 	/* Let's try not to end up here! */
 	function throwTypeError(key: string, payloadType: T): never {
 		throw new TypeError(`Key "${key}" is not valid for a payload sent to ${payloadType} .`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export {
 	isWKSrsStageNumberArray,
 	stringifyParameters,
 	validateParameters,
-	validatePayloads,
+	validatePayload,
 } from "./v20170710.js";
 
 export type {

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -14,7 +14,7 @@ export {
 	isWKSrsStageNumberArray,
 	stringifyParameters,
 	validateParameters,
-	validatePayloads,
+	validatePayload,
 } from "./base/v20170710.js";
 
 export { WK_SUBJECT_MARKUP_MATCHERS } from "./subjects/v20170710.js";

--- a/tests/base/validatePayload.test.ts
+++ b/tests/base/validatePayload.test.ts
@@ -3,7 +3,7 @@ import type { WKStudyMaterialCreatePayload, WKStudyMaterialUpdatePayload } from 
 import type { WKUserPreferences, WKUserPreferencesPayload } from "../../src/user/v20170710";
 import type { WKAssignmentPayload } from "../../src/assignments/v20170710";
 import type { WKReviewPayload } from "../../src/reviews/v20170710";
-import { validatePayloads } from "../../src/base/v20170710";
+import { validatePayload } from "../../src/base/v20170710";
 
 const assignmentStartPayload: Required<WKAssignmentPayload> = {
 	started_at: new Date(),
@@ -50,44 +50,44 @@ const userPreferencesPayload: Required<WKUserPreferencesPayload> = {
 };
 
 it("Successfully validates Assignment Start Payloads", () => {
-	expect(validatePayloads("PUT /assignments/<id>/start", assignmentStartPayload)).toBe(undefined);
+	expect(validatePayload("PUT /assignments/<id>/start", assignmentStartPayload)).toBe(undefined);
 });
 
 it("Successfully validates Review Create Payloads", () => {
-	expect(validatePayloads("POST /reviews", reviewCreatePayloadAssignment)).toBe(undefined);
-	expect(validatePayloads("POST /reviews", reviewCreatePayloadSubject)).toBe(undefined);
+	expect(validatePayload("POST /reviews", reviewCreatePayloadAssignment)).toBe(undefined);
+	expect(validatePayload("POST /reviews", reviewCreatePayloadSubject)).toBe(undefined);
 });
 
 it("Successfully validates Study Material Create Payloads", () => {
-	expect(validatePayloads("POST /study_materials", studyMaterialCreatePayload)).toBe(undefined);
+	expect(validatePayload("POST /study_materials", studyMaterialCreatePayload)).toBe(undefined);
 });
 
 it("Successfully validates Study Material Update Payloads", () => {
-	expect(validatePayloads("PUT /study_materials/<id>", studyMaterialUpdatePayload)).toBe(undefined);
+	expect(validatePayload("PUT /study_materials/<id>", studyMaterialUpdatePayload)).toBe(undefined);
 });
 
 it("Successfully validates User Preferences Update Payloads", () => {
-	expect(validatePayloads("PUT /user", userPreferencesPayload)).toBe(undefined);
+	expect(validatePayload("PUT /user", userPreferencesPayload)).toBe(undefined);
 });
 
 it("Throws errors on bad payloads", () => {
 	/// @ts-expect-error
-	expect(() => validatePayloads("POST /reviews", assignmentStartPayload)).toThrow(
+	expect(() => validatePayload("POST /reviews", assignmentStartPayload)).toThrow(
 		/Key "(?<name>\w+?)" is not valid for a payload sent to POST \/reviews \./u,
 	);
 	/// @ts-expect-error
-	expect(() => validatePayloads("POST /study_materials", assignmentStartPayload)).toThrow(
+	expect(() => validatePayload("POST /study_materials", assignmentStartPayload)).toThrow(
 		/Key "(?<name>\w+?)" is not valid for a payload sent to POST \/study_materials \./u,
 	);
 	/// @ts-expect-error
-	expect(() => validatePayloads("PUT /assignments/<id>/start", reviewCreatePayloadAssignment)).toThrow(
+	expect(() => validatePayload("PUT /assignments/<id>/start", reviewCreatePayloadAssignment)).toThrow(
 		/Key "(?<name>\w+?)" is not valid for a payload sent to PUT \/assignments\/<id>\/start \./u,
 	);
-	expect(() => validatePayloads("PUT /study_materials/<id>", studyMaterialCreatePayload)).toThrow(
+	expect(() => validatePayload("PUT /study_materials/<id>", studyMaterialCreatePayload)).toThrow(
 		/Key "(?<name>\w+?)" is not valid for a payload sent to PUT \/study_materials\/<id> \./u,
 	);
 	/// @ts-expect-error
-	expect(() => validatePayloads("PUT /user", assignmentStartPayload)).toThrow(
+	expect(() => validatePayload("PUT /user", assignmentStartPayload)).toThrow(
 		/Key "(?<name>\w+?)" is not valid for a payload sent to PUT \/user \./u,
 	);
 });


### PR DESCRIPTION
# Description

This PR renames the recently pushed method `validatePayloads` to `validatePayload` (i.e. without an S on the end), as it's better descriptive of what the method does -- validating only one payload passed to the method.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None.

Or some other information pertaining to the PR like breaking tests, etc.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
