### PR TITLE
Tests: Add Code Coverage Reporting

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -26,6 +26,8 @@ jobs:
         run: npm run lint
       - name: Run Unit Tests
         run: npm test
+      - name: Upload Coverage Reports to Codecov
+        uses: codecov/codecov-action@v3
       - name: Build Documentation
         run: npm run build:docs
       - name: Install TypeScript 4.5

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,6 +20,8 @@ jobs:
         run: npm run lint
       - name: Run Unit Tests
         run: npm test
+      - name: Upload Coverage Reports to Codecov
+        uses: codecov/codecov-action@v3
       - name: Build Documentation
         run: npm run build:docs
       - name: Build Library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,6 @@ jobs:
         run: npm run lint
       - name: Run Unit Tests
         run: npm test
-      - name: Upload Coverage Reports to Codecov
-        uses: codecov/codecov-action@v3
       - name: Build Documentation
         run: npm run build:docs
       - name: Build Library

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,8 @@ jobs:
         run: npm run lint
       - name: Run Unit Tests
         run: npm test
+      - name: Upload Coverage Reports to Codecov
+        uses: codecov/codecov-action@v3
       - name: Build Documentation
         run: npm run build:docs
       - name: Build Library

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage
 node_modules
 dist
 /docs

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 90%

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -15,4 +15,7 @@ module.exports = {
 	moduleNameMapper: {
 		"^(\\.{1,2}/.*)\\.js$": "$1",
 	},
+	collectCoverage: true,
+	coverageDirectory: "coverage",
+	coverageProvider: "v8",
 };


### PR DESCRIPTION
# Description

This PR adds Code Coverage Reporting to Codecov, to better ensure we're testing all exported JavaScript properly.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
