### PR TITLE
Base: Describe and Cover TypeError in stringifyParameters()

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -679,7 +679,7 @@ export function isWKSrsStageNumberArray(
  */
 export function stringifyParameters<T extends WKCollectionParameters>(params: T): string {
 	if (typeof params !== "object") {
-		throw new TypeError();
+		throw new TypeError("Parameters must be expressed as an object.");
 	}
 	if (Object.keys(params).length === 0) {
 		return "";

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -675,6 +675,7 @@ export function isWKSrsStageNumberArray(
  *
  * @param params -- An object containing the query string parameters to parse.
  * @returns A query string of all the parameters, which can be added to a base URL.
+ * @throws A `TypeError` if a non-object is passed to the function.
  * @category Base
  */
 export function stringifyParameters<T extends WKCollectionParameters>(params: T): string {

--- a/tests/base/stringifyParameters.test.ts
+++ b/tests/base/stringifyParameters.test.ts
@@ -46,3 +46,9 @@ it("Properly stringifies dates", () => {
 	const expectedString = "?available_after=2022-10-31T12:00:00.000Z&available_before=2021-10-31T12:00:00.000Z";
 	expect(stringifyParameters(params)).toBe(expectedString);
 });
+
+it("Throws an error when passed a non-object", () => {
+	const notAnObject = "not an object";
+	/// @ts-expect-error
+	expect(() => stringifyParameters(notAnObject)).toThrow("Parameters must be expressed as an object.");
+});


### PR DESCRIPTION
# Description

This PR better clarifies a `TypeError` thrown on `stringifyParameters()` if a non-object is passed to the method. TypeScript will disallow this from happening, but if we're going to throw an error, it should be well-documented.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
