### PR TITLE
GitHub: Move TypeScript Changes above Dependency Updates

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,12 +15,12 @@ changelog:
     - title: 📓 Documentation Updates
       labels:
         - documentation
-    - title: 🔄 Dependency Updates
-      labels:
-        - dependencies
     - title: ☑️ TypeScript Changes
       labels:
         - typescript
+    - title: 🔄 Dependency Updates
+      labels:
+        - dependencies
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
# Description

This PR updates our auto-generated release notes on GitHub to put TypeScript Changes above Dependency Updates, as the latter can be quite a long list between versions.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
