### PR TITLE
Chore: Simplify TypeScript Peer Dependency Range

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
 		"typescript": "5.0.4"
 	},
 	"peerDependencies": {
-		"typescript": "^4.5.0 || ^5.0.0"
+		"typescript": ">= 4.5.x < 5.1.x"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
 		"typescript": "5.0.4"
 	},
 	"peerDependencies": {
-		"typescript": ">= 4.5.x < 5.1.x"
+		"typescript": "4.5.x - 5.0.x"
 	}
 }


### PR DESCRIPTION
# Description

This PR updates the `peerDependencies` on `package.json`. TypeScript does not follow Semantic Versioning, and minor versions can contain breaking changes. So at the very least, the version range `^5.0` will need to be changed so that it only resolves to 5.0.x instead of 5.x as a whole.

# Related Issue(s) / Pull Request(s)

#161 

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

We will need to see how Renovate handles the new version range, and make sure it updates it properly.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
