### PR TITLE
Undo grouped exports

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -486,7 +486,6 @@ module.exports = {
     // Import Rules
     "import/exports-last": "error",
     "import/first": "error",
-    "import/group-exports": "error",
     "import/newline-after-import": "error",
     "import/no-absolute-path": "error",
     "import/no-amd": "error",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -18,7 +18,7 @@ import type {
  * @category Assignments
  * @category Resources
  */
-interface WKAssignment extends WKResource {
+export interface WKAssignment extends WKResource {
   /**
    * Date for the returned assignment.
    */
@@ -42,7 +42,7 @@ interface WKAssignment extends WKResource {
  * @category Assignments
  * @category Collections
  */
-interface WKAssignmentCollection extends WKCollection {
+export interface WKAssignmentCollection extends WKCollection {
   /**
    * An array of returned assignments.
    */
@@ -56,7 +56,7 @@ interface WKAssignmentCollection extends WKCollection {
  * @category Assignments
  * @category Data
  */
-interface WKAssignmentData {
+export interface WKAssignmentData {
   /**
    * When the related subject will be available in the user's review queue.
    */
@@ -127,7 +127,7 @@ interface WKAssignmentData {
  * @category Assignments
  * @category Parameters
  */
-interface WKAssignmentParameters extends WKCollectionParameters {
+export interface WKAssignmentParameters extends WKCollectionParameters {
   /**
    * Only assignments available at or after this time are returned.
    */
@@ -207,11 +207,9 @@ interface WKAssignmentParameters extends WKCollectionParameters {
  * @category Assignments
  * @category Payloads
  */
-interface WKAssignmentPayload {
+export interface WKAssignmentPayload {
   /**
    * When the assignment was started. Must be greater than or equal to the assignment's `unlocked_at` date.
    */
   started_at?: Date | WKDatableString;
 }
-
-export type { WKAssignment, WKAssignmentCollection, WKAssignmentData, WKAssignmentParameters, WKAssignmentPayload };

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -50,7 +50,7 @@ import type {
  * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
  * @category Base
  */
-type WKApiRevision = "20170710";
+export type WKApiRevision = "20170710";
 
 /**
  * A constant representing the WaniKani API revision. This will match the revision module being imported from, or the
@@ -59,7 +59,7 @@ type WKApiRevision = "20170710";
  * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
  * @category Base
  */
-const WK_API_REVISION: WKApiRevision = "20170710";
+export const WK_API_REVISION: WKApiRevision = "20170710";
 
 /**
  * The common properties across all Collection items from the WaniKani API.
@@ -68,7 +68,7 @@ const WK_API_REVISION: WKApiRevision = "20170710";
  * @category Base
  * @category Collections
  */
-interface WKCollection {
+export interface WKCollection {
   /**
    * The resource's data, dependent on the collection's resource type.
    */
@@ -147,7 +147,7 @@ interface WKCollection {
  * @category Base
  * @category Parameters
  */
-interface WKCollectionParameters {
+export interface WKCollectionParameters {
   /**
    * Only resources where `data.id` matches one of the array values are returned.
    */
@@ -179,7 +179,7 @@ interface WKCollectionParameters {
  * @category Base
  * @category Parameters
  */
-interface WKCollectionParametersMap {
+export interface WKCollectionParametersMap {
   /**
    * Parameters for Assignment Collections.
    */
@@ -224,14 +224,14 @@ interface WKCollectionParametersMap {
  * @see {@link isWKDatableString}
  * @category Base
  */
-type WKDatableString = Brand<string, "WKDatableString">;
+export type WKDatableString = Brand<string, "WKDatableString">;
 
 /**
  * An error response returned by the WaniKani API.
  *
  * @category Base
  */
-interface WKError {
+export interface WKError {
   /**
    * An HTTP status code indicating the type of error.
    */
@@ -283,91 +283,91 @@ interface WKError {
  *
  * @category Base
  */
-type WKLessonBatchSizeNumber = Range<WKMinLessonBatchSize, WKMaxLessonBatchSize>;
+export type WKLessonBatchSizeNumber = Range<WKMinLessonBatchSize, WKMaxLessonBatchSize>;
 
 /**
  * A number representing a level in WaniKani, from `1` to `60`.
  *
  * @category Base
  */
-type WKLevel = Range<1, WKMaxLevels>;
+export type WKLevel = Range<1, WKMaxLevels>;
 
 /**
  * The maximum batch size for lessons in the WaniKani app.
  *
  * @category Base
  */
-type WKMaxLessonBatchSize = 10;
+export type WKMaxLessonBatchSize = 10;
 
 /**
  * The maximum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-const WK_MAX_LESSON_BATCH_SIZE: WKMaxLessonBatchSize = 10;
+export const WK_MAX_LESSON_BATCH_SIZE: WKMaxLessonBatchSize = 10;
 
 /**
  * The maximum level provided by WaniKani; used to calculate level ranges.
  *
  * @category Base
  */
-type WKMaxLevels = 60;
+export type WKMaxLevels = 60;
 
 /**
  * The maximum level provided by WaniKani; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-const WK_MAX_LEVELS: WKMaxLevels = 60;
+export const WK_MAX_LEVELS: WKMaxLevels = 60;
 
 /**
  * The maximum number of SRS Stages used in WaniKani's reviews.
  *
  * @category Base
  */
-type WKMaxSrsReviewStages = 8;
+export type WKMaxSrsReviewStages = 8;
 
 /**
  * The maximum number of SRS Stages used in WaniKani's reviews; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-const WK_MAX_SRS_REVIEW_STAGES: WKMaxSrsReviewStages = 8;
+export const WK_MAX_SRS_REVIEW_STAGES: WKMaxSrsReviewStages = 8;
 
 /**
  * The maximum number of SRS Stages used in WaniKani's SRS; used to calculate SRS Stage ranges.
  *
  * @category Base
  */
-type WKMaxSrsStages = 9;
+export type WKMaxSrsStages = 9;
 
 /**
  * The maximum number of SRS Stages used in WaniKani's SRS; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-const WK_MAX_SRS_STAGES: WKMaxSrsStages = 9;
+export const WK_MAX_SRS_STAGES: WKMaxSrsStages = 9;
 
 /**
  * The minimum batch size for lessons in the WaniKani app.
  *
  * @category Base
  */
-type WKMinLessonBatchSize = 3;
+export type WKMinLessonBatchSize = 3;
 
 /**
  * The minimum batch size for lessons in the WaniKani app; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-const WK_MIN_LESSON_BATCH_SIZE: WKMinLessonBatchSize = 3;
+export const WK_MIN_LESSON_BATCH_SIZE: WKMinLessonBatchSize = 3;
 
 /**
  * The lowest number of levels that a WaniKani user has access to, when they are on a free subscription.
  *
  * @category Base
  */
-type WKMinLevels = 3;
+export type WKMinLevels = 3;
 
 /**
  * The lowest number of levels that a WaniKani user has access to, when they are on a free subscription; exported for
@@ -375,7 +375,7 @@ type WKMinLevels = 3;
  *
  * @category Base
  */
-const WK_MIN_LEVELS: WKMinLevels = 3;
+export const WK_MIN_LEVELS: WKMinLevels = 3;
 
 /**
  * Map PUT and POST requests to the WaniKani API, to their respective Payload types.
@@ -383,7 +383,7 @@ const WK_MIN_LEVELS: WKMinLevels = 3;
  * @category Base
  * @category Payloads
  */
-interface WKPayloadMap {
+export interface WKPayloadMap {
   /** Payload to create a Review. */
   "POST /reviews": WKReviewPayload;
   /** Payload to create a new Study Material. */
@@ -404,7 +404,7 @@ interface WKPayloadMap {
  * @category Base
  * @category Reports
  */
-interface WKReport {
+export interface WKReport {
   /**
    * The report's data, dependent on the particular report.
    */
@@ -444,7 +444,7 @@ interface WKReport {
  * @category Base
  * @category Resources
  */
-interface WKResource {
+export interface WKResource {
   /**
    * The resource's data, dependent on the particular type of resource.
    */
@@ -501,7 +501,7 @@ interface WKResource {
  * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
  * @category Base
  */
-type WKResourceType =
+export type WKResourceType =
   | "assignment"
   | "level_progression"
   | "reset"
@@ -517,7 +517,7 @@ type WKResourceType =
  *
  * @category Base
  */
-type WKSrsStageNumber = Range<0, WKMaxSrsStages>;
+export type WKSrsStageNumber = Range<0, WKMaxSrsStages>;
 
 /**
  * A non-empty array of WaniKani subject types.
@@ -526,7 +526,7 @@ type WKSrsStageNumber = Range<0, WKMaxSrsStages>;
  * @category Base
  * @category Subjects
  */
-type WKSubjectTuple = [WKSubjectType, ...WKSubjectType[]];
+export type WKSubjectTuple = [WKSubjectType, ...WKSubjectType[]];
 
 /**
  * The types of subjects used on WaniKani and its API.
@@ -535,7 +535,7 @@ type WKSubjectTuple = [WKSubjectType, ...WKSubjectType[]];
  * @category Base
  * @category Subjects
  */
-type WKSubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
+export type WKSubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
 
 /**
  * A type guard to determine if a given item is a valid {@link WKDatableString}.
@@ -544,7 +544,7 @@ type WKSubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
  * @returns `true` if the item is a valid {@link WKDatableString}, `false` if not.
  * @category Base
  */
-function isWKDatableString(possibleWKDatableString: unknown): possibleWKDatableString is WKDatableString {
+export function isWKDatableString(possibleWKDatableString: unknown): possibleWKDatableString is WKDatableString {
   const twentyFourHours = 24;
 
   const datePattern =
@@ -586,7 +586,7 @@ function isWKDatableString(possibleWKDatableString: unknown): possibleWKDatableS
  * @returns `true` if the item is a valid {@link WKLessonBatchSizeNumber}, `false` if not.
  * @category Base
  */
-function isWKLessonBatchSizeNumber(
+export function isWKLessonBatchSizeNumber(
   possibleWKLessonBatchSizeNumber: unknown,
 ): possibleWKLessonBatchSizeNumber is WKLessonBatchSizeNumber {
   return (
@@ -604,7 +604,7 @@ function isWKLessonBatchSizeNumber(
  * @returns `true` if the item is a valid {@link WKLevel}, `false` if not.
  * @category Base
  */
-function isWKLevel(possibleWKLevel: unknown): possibleWKLevel is WKLevel {
+export function isWKLevel(possibleWKLevel: unknown): possibleWKLevel is WKLevel {
   return (
     typeof possibleWKLevel === "number" &&
     Number.isInteger(possibleWKLevel) &&
@@ -620,7 +620,7 @@ function isWKLevel(possibleWKLevel: unknown): possibleWKLevel is WKLevel {
  * @returns `true` if the item is a valid {@link WKLevel} array, `false` if not.
  * @category Base
  */
-function isWKLevelArray(possibleWKLevelArray: unknown): possibleWKLevelArray is WKLevel[] {
+export function isWKLevelArray(possibleWKLevelArray: unknown): possibleWKLevelArray is WKLevel[] {
   if (!Array.isArray(possibleWKLevelArray)) {
     return false;
   }
@@ -641,7 +641,7 @@ function isWKLevelArray(possibleWKLevelArray: unknown): possibleWKLevelArray is 
  * @returns `true` if the item is a valid {@link WKSrsStageNumber}, `false` if not.
  * @category Base
  */
-function isWKSrsStageNumber(possibleWKSrsStageNumber: unknown): possibleWKSrsStageNumber is WKSrsStageNumber {
+export function isWKSrsStageNumber(possibleWKSrsStageNumber: unknown): possibleWKSrsStageNumber is WKSrsStageNumber {
   return (
     typeof possibleWKSrsStageNumber === "number" &&
     Number.isInteger(possibleWKSrsStageNumber) &&
@@ -657,7 +657,7 @@ function isWKSrsStageNumber(possibleWKSrsStageNumber: unknown): possibleWKSrsSta
  * @returns `true` if the item is a valid {@link WKSrsStageNumber} array, `false` if not.
  * @category Base
  */
-function isWKSrsStageNumberArray(
+export function isWKSrsStageNumberArray(
   possibleWKSrsStageNumberArray: unknown,
 ): possibleWKSrsStageNumberArray is WKSrsStageNumber[] {
   if (!Array.isArray(possibleWKSrsStageNumberArray)) {
@@ -681,7 +681,7 @@ function isWKSrsStageNumberArray(
  * @throws A `TypeError` if a non-object is passed to the function.
  * @category Base
  */
-function stringifyParameters<T extends WKCollectionParameters>(params: T): string {
+export function stringifyParameters<T extends WKCollectionParameters>(params: T): string {
   if (typeof params !== "object") {
     throw new TypeError("Parameters must be expressed as an object.");
   }
@@ -724,7 +724,7 @@ function stringifyParameters<T extends WKCollectionParameters>(params: T): strin
  * @throws A `TypeError` if parameter validation fails.
  * @category Base
  */
-function validateParameters<T extends keyof WKCollectionParametersMap>(
+export function validateParameters<T extends keyof WKCollectionParametersMap>(
   type: T,
   params: WKCollectionParametersMap[T],
 ): void {
@@ -841,7 +841,7 @@ function validateParameters<T extends keyof WKCollectionParametersMap>(
  * @category Base
  * @category Payloads
  */
-function validatePayload<T extends keyof WKPayloadMap>(type: T, payload: WKPayloadMap[T]): void {
+export function validatePayload<T extends keyof WKPayloadMap>(type: T, payload: WKPayloadMap[T]): void {
   /* Let's try not to end up here! */
   function throwTypeError(key: string, payloadType: T): never {
     throw new TypeError(`Key "${key}" is not valid for a payload sent to ${payloadType} .`);
@@ -926,43 +926,3 @@ function validatePayload<T extends keyof WKPayloadMap>(type: T, payload: WKPaylo
     }
   });
 }
-
-export {
-  type WKApiRevision,
-  WK_API_REVISION,
-  type WKCollection,
-  type WKCollectionParameters,
-  type WKCollectionParametersMap,
-  type WKDatableString,
-  type WKError,
-  type WKLessonBatchSizeNumber,
-  type WKLevel,
-  type WKMaxLessonBatchSize,
-  WK_MAX_LESSON_BATCH_SIZE,
-  type WKMaxLevels,
-  WK_MAX_LEVELS,
-  type WKMaxSrsReviewStages,
-  WK_MAX_SRS_REVIEW_STAGES,
-  type WKMaxSrsStages,
-  WK_MAX_SRS_STAGES,
-  type WKMinLessonBatchSize,
-  WK_MIN_LESSON_BATCH_SIZE,
-  type WKMinLevels,
-  WK_MIN_LEVELS,
-  type WKPayloadMap,
-  type WKReport,
-  type WKResource,
-  type WKResourceType,
-  type WKSrsStageNumber,
-  type WKSubjectTuple,
-  type WKSubjectType,
-  isWKDatableString,
-  isWKLessonBatchSizeNumber,
-  isWKLevel,
-  isWKLevelArray,
-  isWKSrsStageNumber,
-  isWKSrsStageNumberArray,
-  stringifyParameters,
-  validateParameters,
-  validatePayload,
-};

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -5,7 +5,7 @@
  */
 
 /* eslint-disable-next-line @typescript-eslint/naming-convention -- Need double undercore for Type Branding */
-type Brand<K, T> = K & { __brand: T };
+export type Brand<K, T> = K & { __brand: T };
 
 /**
  * Tail-recursion for excluding numbers.
@@ -14,7 +14,7 @@ type Brand<K, T> = K & { __brand: T };
  *
  * @internal
  */
-type Enumerate<N extends number, Acc extends number[] = []> = Acc["length"] extends N
+export type Enumerate<N extends number, Acc extends number[] = []> = Acc["length"] extends N
   ? Acc[number]
   : Enumerate<N, [...Acc, Acc["length"]]>;
 
@@ -28,7 +28,7 @@ type Enumerate<N extends number, Acc extends number[] = []> = Acc["length"] exte
  * @internal
  */
 
-type Range<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>> | T;
+export type Range<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate<F>> | T;
 
 /**
  * Checks if a given year, month, and day compose a valid date.
@@ -39,7 +39,7 @@ type Range<F extends number, T extends number> = Exclude<Enumerate<T>, Enumerate
  * @returns `true` if the year, month, and day are a valid date, `false` if not.
  * @internal
  */
-function isValidDate(year: number, month: number, day: number): boolean {
+export function isValidDate(year: number, month: number, day: number): boolean {
   const fourYears = 4;
   const oneHundredYears = 100;
   const fourHundredYears = 400;
@@ -89,5 +89,3 @@ function isValidDate(year: number, month: number, day: number): boolean {
   }
   return true;
 }
-
-export { type Brand, type Enumerate, type Range, isValidDate };

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -14,7 +14,7 @@ import type { WKCollection, WKCollectionParameters, WKDatableString, WKLevel, WK
  * @category Level Progressions
  * @category Resources
  */
-interface WKLevelProgression extends WKResource {
+export interface WKLevelProgression extends WKResource {
   /**
    * Data for the returned level progression.
    */
@@ -38,7 +38,7 @@ interface WKLevelProgression extends WKResource {
  * @category Collections
  * @category Level Progressions
  */
-interface WKLevelProgressionCollection extends WKCollection {
+export interface WKLevelProgressionCollection extends WKCollection {
   /**
    * An array of returned level progressions.
    */
@@ -52,7 +52,7 @@ interface WKLevelProgressionCollection extends WKCollection {
  * @category Data
  * @category Level Progressions
  */
-interface WKLevelProgressionData {
+export interface WKLevelProgressionData {
   /**
    * Timestamp when the user abandons the level. This is primarily used when the user initiates a reset.
    */
@@ -98,6 +98,4 @@ interface WKLevelProgressionData {
  * @category Level Progressions
  * @category Parameters
  */
-type WKLevelProgressionParameters = WKCollectionParameters;
-
-export type { WKLevelProgression, WKLevelProgressionCollection, WKLevelProgressionData, WKLevelProgressionParameters };
+export type WKLevelProgressionParameters = WKCollectionParameters;

--- a/src/requests/v20170710.ts
+++ b/src/requests/v20170710.ts
@@ -25,7 +25,7 @@ const baseUrl = "https://api.wanikani.com/v2";
  * @see {@link WKRequestFactory}
  * @category Requests
  */
-interface WKRequest {
+export interface WKRequest {
   /** The request body, either `null` for GET requests, or a `string` for POST and PUT requests. */
   body: string | null;
   /** The request headers, including both standard and user-set headers. */
@@ -42,7 +42,7 @@ interface WKRequest {
  *
  * @category Requests
  */
-class WKRequestFactory {
+export class WKRequestFactory {
   /**
    * The headers set on factory initialization, excluding anything in the `customHeaders` property in
    * {@link WKRequestFactoryInit}.
@@ -666,7 +666,7 @@ class WKRequestFactory {
  *
  * @category Requests
  */
-interface WKRequestFactoryInit {
+export interface WKRequestFactoryInit {
   /** The WaniKani API Token to use in the requests. */
   apiToken: string;
   /** Any additional headers to be added to all requests. */
@@ -682,7 +682,7 @@ interface WKRequestFactoryInit {
  *
  * @category Requests
  */
-interface WKRequestGetOptions {
+export interface WKRequestGetOptions {
   /** Custom headers to add to this request only. */
   customHeaders?: Record<string, string>;
   /** Adds an `If-Modified-Since` header to the request. */
@@ -696,7 +696,7 @@ interface WKRequestGetOptions {
  *
  * @category Requests
  */
-interface WKRequestHeaders {
+export interface WKRequestHeaders {
   /** HTTP Authorization header, using a Bearer Token. */
   Authorization: `Bearer ${string}`;
   /** The WaniKani API Revision. */
@@ -719,7 +719,7 @@ interface WKRequestHeaders {
  *
  * @category Requests
  */
-interface WKRequestPostPutOptions {
+export interface WKRequestPostPutOptions {
   /** Custom headers to add to this request only. */
   customHeaders?: Record<string, string>;
 }
@@ -730,7 +730,7 @@ interface WKRequestPostPutOptions {
  * @category Assignments
  * @category Requests
  */
-interface WKAssignmentRequests {
+export interface WKAssignmentRequests {
   /**
    * Get an Assignment or Assignment Collection from the WaniKani API.
    * @param idOrParams The Assignment ID for individual Assignments, or parameters for Assignment Collections.
@@ -755,7 +755,7 @@ interface WKAssignmentRequests {
  * @category Level Progressions
  * @category Requests
  */
-interface WKLevelProgressionRequests {
+export interface WKLevelProgressionRequests {
   /**
    * Get a Level Progression or Level Progression Collection from the WaniKani API.
    * @param idOrParams The Level Progression ID for individual Level Progressions, or parameters for Level
@@ -772,7 +772,7 @@ interface WKLevelProgressionRequests {
  * @category Requests
  * @category Resets
  */
-interface WKResetRequests {
+export interface WKResetRequests {
   /**
    * Get a Reset or Reset Collection from the WaniKani API.
    * @param idOrParams The Reset ID for individual Resets, or parameters for Reset Collections.
@@ -788,7 +788,7 @@ interface WKResetRequests {
  * @category Requests
  * @category Reviews
  */
-interface WKReviewRequests {
+export interface WKReviewRequests {
   /**
    * Create a new Review via the WaniKani API.
    * @param payload The payload to send when creating the Review.
@@ -811,7 +811,7 @@ interface WKReviewRequests {
  * @category Requests
  * @category Review Statistics
  */
-interface WKReviewStatisticRequests {
+export interface WKReviewStatisticRequests {
   /**
    * Get a Review Statistic or Review Statistic Collection from the WaniKani API.
    * @param idOrParams The Review Statistic ID for individual Review Statistics, or parameters for Review Statistic
@@ -828,7 +828,7 @@ interface WKReviewStatisticRequests {
  * @category Requests
  * @category Spaced Repetition Systems
  */
-interface WKSpacedRepetitionSystemRequests {
+export interface WKSpacedRepetitionSystemRequests {
   /**
    * Get a Spaced Repetition System (SRS) or Spaced Repetition System (SRS) Collection from the WaniKani API.
    * @param idOrParams The Spaced Repetition System (SRS) ID for individual Spaced Repetition Systems (SRS), or
@@ -845,7 +845,7 @@ interface WKSpacedRepetitionSystemRequests {
  * @category Requests
  * @category Study Materials
  */
-interface WKStudyMaterialRequests {
+export interface WKStudyMaterialRequests {
   /**
    * Create a new Study Material for a given Subject via the WaniKani API.
    * @param payload The payload to send when creating the new Study Material.
@@ -878,7 +878,7 @@ interface WKStudyMaterialRequests {
  * @category Requests
  * @category Subjects
  */
-interface WKSubjectRequests {
+export interface WKSubjectRequests {
   /**
    * Get a Subject or Subject Collection from the WaniKani API.
    * @param idOrParams The Subject ID for individual Subjects, or parameters for Subject Collections.
@@ -894,7 +894,7 @@ interface WKSubjectRequests {
  * @category Requests
  * @category Summary
  */
-interface WKSummaryRequests {
+export interface WKSummaryRequests {
   /**
    * Get a summary of a user's available and upcoming lessons/reviews from the WaniKani API.
    *
@@ -910,7 +910,7 @@ interface WKSummaryRequests {
  * @category Requests
  * @category User
  */
-interface WKUserRequests {
+export interface WKUserRequests {
   /**
    * Get a user's information from the WaniKani API.
    *
@@ -935,7 +935,7 @@ interface WKUserRequests {
  * @category Requests
  * @category Voice Actors
  */
-interface WKVoiceActorRequests {
+export interface WKVoiceActorRequests {
   /**
    * Get a Voice Actor or Voice Actor Collection from the WaniKani API.
    * @param idOrParams The Voice Actor ID for individual Voice Actors, or parameters for Voice Actor Collections.
@@ -944,23 +944,3 @@ interface WKVoiceActorRequests {
    */
   get: (idOrParams?: WKVoiceActorParameters | number, options?: WKRequestGetOptions) => WKRequest;
 }
-
-export {
-  type WKAssignmentRequests,
-  type WKLevelProgressionRequests,
-  type WKRequest,
-  WKRequestFactory,
-  type WKRequestFactoryInit,
-  type WKRequestGetOptions,
-  type WKRequestHeaders,
-  type WKRequestPostPutOptions,
-  type WKResetRequests,
-  type WKReviewRequests,
-  type WKReviewStatisticRequests,
-  type WKSpacedRepetitionSystemRequests,
-  type WKStudyMaterialRequests,
-  type WKSubjectRequests,
-  type WKSummaryRequests,
-  type WKUserRequests,
-  type WKVoiceActorRequests,
-};

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -10,7 +10,7 @@ import type { WKCollection, WKCollectionParameters, WKDatableString, WKLevel, WK
  * @category Resets
  * @category Resources
  */
-interface WKReset extends WKResource {
+export interface WKReset extends WKResource {
   /**
    * Data for the returned reset.
    */
@@ -34,7 +34,7 @@ interface WKReset extends WKResource {
  * @category Collections
  * @category Resets
  */
-interface WKResetCollection extends WKCollection {
+export interface WKResetCollection extends WKCollection {
   /**
    * An array of returned resets.
    */
@@ -48,7 +48,7 @@ interface WKResetCollection extends WKCollection {
  * @category Data
  * @category Resets
  */
-interface WKResetData {
+export interface WKResetData {
   /**
    * Timestamp when the user confirmed the reset.
    */
@@ -78,6 +78,4 @@ interface WKResetData {
  * @category Parameters
  * @category Resets
  */
-type WKResetParameters = WKCollectionParameters;
-
-export type { WKReset, WKResetCollection, WKResetData, WKResetParameters };
+export type WKResetParameters = WKCollectionParameters;

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -18,7 +18,7 @@ import type {
  * @category Resources
  * @category Review Statistics
  */
-interface WKReviewStatistic extends WKResource {
+export interface WKReviewStatistic extends WKResource {
   /**
    * Data for the returned review statistic.
    */
@@ -42,7 +42,7 @@ interface WKReviewStatistic extends WKResource {
  * @category Collections
  * @category Review Statistics
  */
-interface WKReviewStatisticCollection extends WKCollection {
+export interface WKReviewStatisticCollection extends WKCollection {
   /**
    * An array of returned review statistics.
    */
@@ -56,7 +56,7 @@ interface WKReviewStatisticCollection extends WKCollection {
  * @category Data
  * @category Review Statistics
  */
-interface WKReviewStatisticData {
+export interface WKReviewStatisticData {
   /**
    * Timestamp when the review statistic was created.
    */
@@ -131,7 +131,7 @@ interface WKReviewStatisticData {
  * @category Parameters
  * @category Review Statistics
  */
-interface WKReviewStatisticParameters extends WKCollectionParameters {
+export interface WKReviewStatisticParameters extends WKCollectionParameters {
   /**
    * Return review statistics with a matching value in the `hidden` attribute.
    */
@@ -158,5 +158,3 @@ interface WKReviewStatisticParameters extends WKCollectionParameters {
    */
   subject_types?: WKSubjectTuple;
 }
-
-export type { WKReviewStatistic, WKReviewStatisticCollection, WKReviewStatisticData, WKReviewStatisticParameters };

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -11,13 +11,39 @@ import type {
 import type { Range } from "../internal";
 
 /**
+ * The base object used in the request to create a new review via the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
+ * @category Reviews
+ * @internal
+ */
+interface WKReviewObjectdBase {
+  /**
+   * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
+   */
+  incorrect_meaning_answers: number;
+
+  /**
+   * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
+   * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
+   */
+  incorrect_reading_answers: number;
+
+  /**
+   * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
+   * Must be in the past, but after `assignment.available_at`.
+   */
+  created_at?: Date | WKDatableString;
+}
+
+/**
  * A created review returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
  * @category Resources
  * @category Reviews
  */
-interface WKCreatedReview extends WKResource {
+export interface WKCreatedReview extends WKResource {
   /**
    * Data for the created review.
    * @see {@link https://docs.api.wanikani.com/20170710/#reviews}
@@ -61,7 +87,7 @@ interface WKCreatedReview extends WKResource {
  * @category Resources
  * @category Reviews
  */
-interface WKReview extends WKResource {
+export interface WKReview extends WKResource {
   /**
    * Data for the returned review.
    */
@@ -85,7 +111,7 @@ interface WKReview extends WKResource {
  * @category Collections
  * @category Reviews
  */
-interface WKReviewCollection extends WKCollection {
+export interface WKReviewCollection extends WKCollection {
   /**
    * An array of returned reviews.
    */
@@ -99,7 +125,7 @@ interface WKReviewCollection extends WKCollection {
  * @category Data
  * @category Reviews
  */
-interface WKReviewData {
+export interface WKReviewData {
   /**
    * Unique identifier of the associated assignment.
    */
@@ -150,7 +176,7 @@ interface WKReviewData {
  * @category Parameters
  * @category Reviews
  */
-interface WKReviewParameters extends WKCollectionParameters {
+export interface WKReviewParameters extends WKCollectionParameters {
   /**
    * Only reviews where `data.assignment_id` matches one of the array values are returned.
    */
@@ -163,37 +189,12 @@ interface WKReviewParameters extends WKCollectionParameters {
 }
 
 /**
- * The base object used in the request to create a new review via the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
- * @category Reviews
- */
-interface WKReviewObjectdBase {
-  /**
-   * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
-   */
-  incorrect_meaning_answers: number;
-
-  /**
-   * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
-   * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
-   */
-  incorrect_reading_answers: number;
-
-  /**
-   * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
-   * Must be in the past, but after `assignment.available_at`.
-   */
-  created_at?: Date | WKDatableString;
-}
-
-/**
  * The review object used in the request to create a new review via the WaniKani API by Assignment ID.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
  * @category Reviews
  */
-interface WKReviewObjectWithAssignmentId extends WKReviewObjectdBase {
+export interface WKReviewObjectWithAssignmentId extends WKReviewObjectdBase {
   /**
    * Unique identifier of the assignment. This or `subject_id` must be set.
    */
@@ -211,7 +212,7 @@ interface WKReviewObjectWithAssignmentId extends WKReviewObjectdBase {
  * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
  * @category Reviews
  */
-interface WKReviewObjectWithSubjectId extends WKReviewObjectdBase {
+export interface WKReviewObjectWithSubjectId extends WKReviewObjectdBase {
   /**
    * Unique identifier of the subject. This or `assignment_id` must be set.
    */
@@ -230,20 +231,9 @@ interface WKReviewObjectWithSubjectId extends WKReviewObjectdBase {
  * @category Payloads
  * @category Reviews
  */
-interface WKReviewPayload {
+export interface WKReviewPayload {
   /**
    * A review object with either the `assignment_id` or `subject_id` specified.
    */
   review: WKReviewObjectWithAssignmentId | WKReviewObjectWithSubjectId;
 }
-
-export type {
-  WKCreatedReview,
-  WKReview,
-  WKReviewCollection,
-  WKReviewData,
-  WKReviewObjectWithAssignmentId,
-  WKReviewObjectWithSubjectId,
-  WKReviewParameters,
-  WKReviewPayload,
-};

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -14,7 +14,7 @@ import type {
  * @category Resources
  * @category Spaced Repetition Systems
  */
-interface WKSpacedRepetitionSystem extends WKResource {
+export interface WKSpacedRepetitionSystem extends WKResource {
   /**
    * Data for the return Spaced Repetition System.
    */
@@ -38,7 +38,7 @@ interface WKSpacedRepetitionSystem extends WKResource {
  * @category Collections
  * @category Spaced Repetition Systems
  */
-interface WKSpacedRepetitionSystemCollection extends WKCollection {
+export interface WKSpacedRepetitionSystemCollection extends WKCollection {
   /**
    * An array of returned Spaced Repetition Systems.
    */
@@ -52,7 +52,7 @@ interface WKSpacedRepetitionSystemCollection extends WKCollection {
  * @category Data
  * @category Spaced Repetition Systems
  */
-interface WKSpacedRepetitionSystemData {
+export interface WKSpacedRepetitionSystemData {
   /**
    * `position` of the burning stage.
    */
@@ -102,7 +102,7 @@ interface WKSpacedRepetitionSystemData {
  * @category Parameters
  * @category Spaced Repetition Systems
  */
-type WKSpacedRepetitionSystemParameters = WKCollectionParameters;
+export type WKSpacedRepetitionSystemParameters = WKCollectionParameters;
 
 /**
  * An individual Spaced Repetition System (SRS) Stage.
@@ -110,7 +110,7 @@ type WKSpacedRepetitionSystemParameters = WKCollectionParameters;
  * @see {@link https://docs.api.wanikani.com/20170710/#spaced-repetition-systems}
  * @category Spaced Repetition Systems
  */
-interface WKSpacedRepetitionSystemStage {
+export interface WKSpacedRepetitionSystemStage {
   /**
    * The length of time added to the time of review registration, adjusted to the beginning of the hour.
    */
@@ -126,11 +126,3 @@ interface WKSpacedRepetitionSystemStage {
    */
   position: WKSrsStageNumber;
 }
-
-export type {
-  WKSpacedRepetitionSystem,
-  WKSpacedRepetitionSystemCollection,
-  WKSpacedRepetitionSystemData,
-  WKSpacedRepetitionSystemParameters,
-  WKSpacedRepetitionSystemStage,
-};

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -15,7 +15,7 @@ import type {
  * @category Resources
  * @category Study Materials
  */
-interface WKStudyMaterial extends WKResource {
+export interface WKStudyMaterial extends WKResource {
   /**
    * Data for the returned study material.
    */
@@ -40,7 +40,7 @@ interface WKStudyMaterial extends WKResource {
  * @remarks For creating study materials, use {@link WKStudyMaterialCreatePayload}; for updating study materials, use
  * {@link WKStudyMaterialUpdatePayload}; for study materials received from the API, use {@link WKStudyMaterialData}.
  */
-interface WKStudyMaterialBaseData {
+export interface WKStudyMaterialBaseData {
   /**
    * Free form note related to the meaning(s) of the associated subject.
    */
@@ -64,7 +64,7 @@ interface WKStudyMaterialBaseData {
  * @category Collections
  * @category Study Materials
  */
-interface WKStudyMaterialCollection extends WKCollection {
+export interface WKStudyMaterialCollection extends WKCollection {
   /**
    * An array of returned study materials.
    */
@@ -78,7 +78,7 @@ interface WKStudyMaterialCollection extends WKCollection {
  * @category Payloads
  * @category Study Materials
  */
-interface WKStudyMaterialCreatePayload extends WKStudyMaterialUpdatePayload {
+export interface WKStudyMaterialCreatePayload extends WKStudyMaterialUpdatePayload {
   /**
    * Unique identifier of the associated subject.
    */
@@ -92,7 +92,7 @@ interface WKStudyMaterialCreatePayload extends WKStudyMaterialUpdatePayload {
  * @category Data
  * @category Study Materials
  */
-interface WKStudyMaterialData extends WKStudyMaterialBaseData {
+export interface WKStudyMaterialData extends WKStudyMaterialBaseData {
   /**
    * Timestamp when the study material was created.
    */
@@ -122,7 +122,7 @@ interface WKStudyMaterialData extends WKStudyMaterialBaseData {
  * @category Parameters
  * @category Study Materials
  */
-interface WKStudyMaterialParameters extends WKCollectionParameters {
+export interface WKStudyMaterialParameters extends WKCollectionParameters {
   /**
    * Return study materials with a matching value in the `hidden` attribute.
    */
@@ -147,14 +147,4 @@ interface WKStudyMaterialParameters extends WKCollectionParameters {
  * @category Payloads
  * @category Study Materials
  */
-type WKStudyMaterialUpdatePayload = Partial<WKStudyMaterialBaseData>;
-
-export type {
-  WKStudyMaterial,
-  WKStudyMaterialBaseData,
-  WKStudyMaterialCollection,
-  WKStudyMaterialCreatePayload,
-  WKStudyMaterialData,
-  WKStudyMaterialParameters,
-  WKStudyMaterialUpdatePayload,
-};
+export type WKStudyMaterialUpdatePayload = Partial<WKStudyMaterialBaseData>;

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -19,7 +19,7 @@ import type {
  * @category Resources
  * @category Subjects
  */
-interface WKKanaVocabulary extends WKResource {
+export interface WKKanaVocabulary extends WKResource {
   /**
    * Data for the returned vocabulary.
    */
@@ -43,7 +43,7 @@ interface WKKanaVocabulary extends WKResource {
  * @category Collections
  * @category Subjects
  */
-interface WKKanaVocabularyCollection extends WKCollection {
+export interface WKKanaVocabularyCollection extends WKCollection {
   /**
    * An array of returned vocabulary subjects.
    */
@@ -57,7 +57,7 @@ interface WKKanaVocabularyCollection extends WKCollection {
  * @category Data
  * @category Subjects
  */
-interface WKKanaVocabularyData extends WKSubjectData {
+export interface WKKanaVocabularyData extends WKSubjectData {
   /**
    * The UTF-8 characters for the subject, including kanji and hiragana.
    */
@@ -131,7 +131,7 @@ interface WKKanaVocabularyData extends WKSubjectData {
  * @category Resources
  * @category Subjects
  */
-interface WKKanji extends WKResource {
+export interface WKKanji extends WKResource {
   /**
    * Data for the returned kanji.
    */
@@ -155,7 +155,7 @@ interface WKKanji extends WKResource {
  * @category Collections
  * @category Subjects
  */
-interface WKKanjiCollection extends WKCollection {
+export interface WKKanjiCollection extends WKCollection {
   /**
    * An array of returned kanji subjects.
    */
@@ -169,7 +169,7 @@ interface WKKanjiCollection extends WKCollection {
  * @category Data
  * @category Subjects
  */
-interface WKKanjiData extends WKSubjectData {
+export interface WKKanjiData extends WKSubjectData {
   /**
    * An array of numeric identifiers for the vocabulary that have the kanji as a component.
    */
@@ -238,7 +238,7 @@ interface WKKanjiData extends WKSubjectData {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKKanjiReading {
+export interface WKKanjiReading {
   /**
    * Indicates if the reading is used to evaluate user input for correctness.
    */
@@ -272,7 +272,7 @@ interface WKKanjiReading {
  * @category Resources
  * @category Subjects
  */
-interface WKRadical extends WKResource {
+export interface WKRadical extends WKResource {
   /**
    * Data for the returned radical.
    */
@@ -295,7 +295,7 @@ interface WKRadical extends WKResource {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKRadicalCharacterImage {
+export interface WKRadicalCharacterImage {
   /**
    * The content type of the image. Currently the API delivers `image/png` and `image/svg+xml`.
    */
@@ -318,7 +318,7 @@ interface WKRadicalCharacterImage {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKRadicalCharacterImagePngMetadata {
+export interface WKRadicalCharacterImagePngMetadata {
   /**
    * Color of the asset in hexadecimal.
    */
@@ -346,7 +346,7 @@ interface WKRadicalCharacterImagePngMetadata {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKRadicalCharacterImageSvgMetadata {
+export interface WKRadicalCharacterImageSvgMetadata {
   /**
    * The SVG asset contains built-in CSS styling.
    */
@@ -375,7 +375,7 @@ interface WKRadicalCharacterImageSvgMetadata {
  * @category Collections
  * @category Subjects
  */
-interface WKRadicalCollection extends WKCollection {
+export interface WKRadicalCollection extends WKCollection {
   /**
    * An array of returned radical subjects.
    */
@@ -389,7 +389,7 @@ interface WKRadicalCollection extends WKCollection {
  * @category Data
  * @category Subjects
  */
-interface WKRadicalData extends WKSubjectData {
+export interface WKRadicalData extends WKSubjectData {
   /**
    * An array of numeric identifiers for the kanji that have the radical as a component.
    */
@@ -457,7 +457,7 @@ interface WKRadicalData extends WKSubjectData {
  * @category Resources
  * @category Subjects
  */
-type WKSubject = WKKanaVocabulary | WKKanji | WKRadical | WKVocabulary;
+export type WKSubject = WKKanaVocabulary | WKKanji | WKRadical | WKVocabulary;
 
 /**
  * A subject's auxilliary meanings.
@@ -465,7 +465,7 @@ type WKSubject = WKKanaVocabulary | WKKanji | WKRadical | WKVocabulary;
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKSubjectAuxiliaryMeaning {
+export interface WKSubjectAuxiliaryMeaning {
   /**
    * A singular subject meaning.
    */
@@ -485,7 +485,7 @@ interface WKSubjectAuxiliaryMeaning {
  * @category Collections
  * @category Subjects
  */
-interface WKSubjectCollection extends WKCollection {
+export interface WKSubjectCollection extends WKCollection {
   /**
    * An array of returned subjects of mixed or unknown type.
    */
@@ -503,7 +503,7 @@ interface WKSubjectCollection extends WKCollection {
  * @category Data
  * @category Subjects
  */
-interface WKSubjectData {
+export interface WKSubjectData {
   /**
    * Collection of auxiliary meanings.
    */
@@ -573,7 +573,7 @@ interface WKSubjectData {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-const WK_SUBJECT_MARKUP_MATCHERS = {
+export const WK_SUBJECT_MARKUP_MATCHERS = {
   /**
    * A regular expression literal that matches to Japanese text surrounded by `<ja>` tags.
    */
@@ -611,7 +611,7 @@ const WK_SUBJECT_MARKUP_MATCHERS = {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKSubjectMeaning {
+export interface WKSubjectMeaning {
   /**
    * Indicates if the meaning is used to evaluate user input for correctness.
    */
@@ -636,7 +636,7 @@ interface WKSubjectMeaning {
  * @category Parameters
  * @category Subjects
  */
-interface WKSubjectParameters extends WKCollectionParameters {
+export interface WKSubjectParameters extends WKCollectionParameters {
   /**
    * Return subjects which are or are not hidden from the user-facing application.
    */
@@ -670,7 +670,7 @@ interface WKSubjectParameters extends WKCollectionParameters {
  * @category Resources
  * @category Subjects
  */
-interface WKVocabulary extends WKResource {
+export interface WKVocabulary extends WKResource {
   /**
    * Data for the returned vocabulary.
    */
@@ -694,7 +694,7 @@ interface WKVocabulary extends WKResource {
  * @category Collections
  * @category Subjects
  */
-interface WKVocabularyCollection extends WKCollection {
+export interface WKVocabularyCollection extends WKCollection {
   /**
    * An array of returned vocabulary subjects.
    */
@@ -707,7 +707,7 @@ interface WKVocabularyCollection extends WKCollection {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKVocabularyContextSentence {
+export interface WKVocabularyContextSentence {
   /**
    * English translation of the sentence.
    */
@@ -726,7 +726,7 @@ interface WKVocabularyContextSentence {
  * @category Data
  * @category Subjects
  */
-interface WKVocabularyData extends WKSubjectData {
+export interface WKVocabularyData extends WKSubjectData {
   /**
    * The UTF-8 characters for the subject, including kanji and hiragana.
    */
@@ -795,7 +795,7 @@ interface WKVocabularyData extends WKSubjectData {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKVocabularyPronunciationAudio {
+export interface WKVocabularyPronunciationAudio {
   /**
    * The content type of the audio. Currently the API delivers `audio/mpeg`, `audio/ogg`, and `audio/webm`.
    */
@@ -848,7 +848,7 @@ interface WKVocabularyPronunciationAudio {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-interface WKVocabularyReading {
+export interface WKVocabularyReading {
   /**
    * Indicates if the reading is used to evaluate user input for correctness.
    */
@@ -869,32 +869,3 @@ interface WKVocabularyReading {
    */
   type?: never;
 }
-
-export {
-  type WKKanaVocabulary,
-  type WKKanaVocabularyCollection,
-  type WKKanaVocabularyData,
-  type WKKanji,
-  type WKKanjiCollection,
-  type WKKanjiData,
-  type WKKanjiReading,
-  type WKRadical,
-  type WKRadicalCharacterImage,
-  type WKRadicalCharacterImagePngMetadata,
-  type WKRadicalCharacterImageSvgMetadata,
-  type WKRadicalCollection,
-  type WKRadicalData,
-  type WKSubject,
-  type WKSubjectAuxiliaryMeaning,
-  type WKSubjectCollection,
-  type WKSubjectData,
-  WK_SUBJECT_MARKUP_MATCHERS,
-  type WKSubjectMeaning,
-  type WKSubjectParameters,
-  type WKVocabulary,
-  type WKVocabularyCollection,
-  type WKVocabularyContextSentence,
-  type WKVocabularyData,
-  type WKVocabularyPronunciationAudio,
-  type WKVocabularyReading,
-};

--- a/src/summary/v20170710.ts
+++ b/src/summary/v20170710.ts
@@ -8,7 +8,7 @@ import type { WKDatableString, WKReport } from "../v20170710.js";
  * @category Reports
  * @category Summary
  */
-interface WKSummary extends WKReport {
+export interface WKSummary extends WKReport {
   /**
    * Data for the Summary report.
    */
@@ -22,7 +22,7 @@ interface WKSummary extends WKReport {
  * @category Data
  * @category Summary
  */
-interface WKSummaryData {
+export interface WKSummaryData {
   /**
    * Details about subjects available for lessons.
    */
@@ -45,7 +45,7 @@ interface WKSummaryData {
  * @see {@link https://docs.api.wanikani.com/20170710/#summary}
  * @category Summary
  */
-interface WKSummaryLesson {
+export interface WKSummaryLesson {
   /**
    * When the paired `subject_ids` are available for lessons. Always beginning of the current hour when the API endpoint
    * is accessed.
@@ -64,7 +64,7 @@ interface WKSummaryLesson {
  * @see {@link https://docs.api.wanikani.com/20170710/#summary}
  * @category Summary
  */
-interface WKSummaryReview {
+export interface WKSummaryReview {
   /**
    * When the paired `subject_ids` are available for reviews. All timestamps are the top of an hour.
    */
@@ -75,5 +75,3 @@ interface WKSummaryReview {
    */
   subject_ids: number[];
 }
-
-export type { WKSummary, WKSummaryData, WKSummaryLesson, WKSummaryReview };

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -14,7 +14,7 @@ import type {
  * @category Resources
  * @category User
  */
-interface WKUser extends WKResource {
+export interface WKUser extends WKResource {
   /**
    * Data for the returned user.
    */
@@ -35,7 +35,7 @@ interface WKUser extends WKResource {
  * @category Data
  * @category User
  */
-interface WKUserData {
+export interface WKUserData {
   /**
    * If the user is on vacation, this will be the timestamp of when that vacation started. If the user is not on
    * vacation, this is `null`.
@@ -84,7 +84,7 @@ interface WKUserData {
  * @see {@link https://docs.api.wanikani.com/20170710/#user}
  * @category User
  */
-interface WKUserPreferences {
+export interface WKUserPreferences {
   /**
    * The voice actor to be used for lessons and reviews. The value is associated to
    * `subject.pronunciation_audios.metadata.voice_actor_id`.
@@ -135,7 +135,7 @@ interface WKUserPreferences {
  * @category Payloads
  * @category User
  */
-interface WKUserPreferencesPayload {
+export interface WKUserPreferencesPayload {
   /**
    * The user object, as part of the payload.
    */
@@ -153,7 +153,7 @@ interface WKUserPreferencesPayload {
  * @see {@link https://docs.api.wanikani.com/20170710/#user}
  * @category User
  */
-interface WKUserSubscription {
+export interface WKUserSubscription {
   /**
    * Whether or not the user currently has a paid subscription.
    */
@@ -180,5 +180,3 @@ interface WKUserSubscription {
    */
   type: "free" | "lifetime" | "recurring" | "unknown";
 }
-
-export type { WKUser, WKUserData, WKUserPreferences, WKUserPreferencesPayload, WKUserSubscription };

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -7,7 +7,7 @@ import type { WKCollection, WKCollectionParameters, WKDatableString, WKResource 
  * @category Resources
  * @category Voice Actors
  */
-interface WKVoiceActor extends WKResource {
+export interface WKVoiceActor extends WKResource {
   /**
    * Data for the returned voice actor.
    */
@@ -31,7 +31,7 @@ interface WKVoiceActor extends WKResource {
  * @category Collections
  * @category Voice Actors
  */
-interface WKVoiceActorCollection extends WKCollection {
+export interface WKVoiceActorCollection extends WKCollection {
   /**
    * An array of returned voice actors.
    */
@@ -45,7 +45,7 @@ interface WKVoiceActorCollection extends WKCollection {
  * @category Data
  * @category Voice Actors
  */
-interface WKVoiceActorData {
+export interface WKVoiceActorData {
   /**
    * Timestamp for when the voice actor was added to WaniKani.
    */
@@ -74,6 +74,4 @@ interface WKVoiceActorData {
  * @category Parameters
  * @category Voice Actors
  */
-type WKVoiceActorParameters = WKCollectionParameters;
-
-export type { WKVoiceActor, WKVoiceActorCollection, WKVoiceActorData, WKVoiceActorParameters };
+export type WKVoiceActorParameters = WKCollectionParameters;


### PR DESCRIPTION
# Description

This PR remove a lint rule concerning grouping exports at the very end of files, and reverts source code to exporting at the declaration as it was before; we do have a rule that requires exports to be last, which should do well enough in catching un-exported or unintentionally exported items -- as was the original goal.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
