### PR TITLE
Base: Remove Unneeded Template Literal

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -699,7 +699,7 @@ export function stringifyParameters<T extends WKCollectionParameters>(params: T)
     if (emptyQueryParams.includes(key) && typeof value === "boolean") {
       if (value) {
         queryString += isFirstItem ? "?" : "&";
-        queryString += `${key}`;
+        queryString += key;
       }
     } else {
       queryString += isFirstItem ? "?" : "&";


### PR DESCRIPTION
# Description

This PR fixes a linting error introduced with the latest version of `typescript-eslint`, which now checks for pointless template literal expressions. 

# Related Issue(s) / Pull Request(s)

Should unblock #267 

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
