### PR TITLE
GitHub: Add TypeScript 5.4 and 5.5 to Pull Request Tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -66,3 +66,11 @@ jobs:
         run: 'npm install --no-save typescript@"~5.3"'
       - name: Build Library on TypeScript 5.3
         run: npm run build
+      - name: Install TypeScript 5.4
+        run: 'npm install --no-save typescript@"~5.4"'
+      - name: Build Library on TypeScript 5.4
+        run: npm run build
+      - name: Install TypeScript 5.5
+        run: 'npm install --no-save typescript@"~5.5"'
+      - name: Build Library on TypeScript 5.5
+        run: npm run build


### PR DESCRIPTION
# Description

This PR adds TypeScript 5.4 and 5.5 to the PR Tests, so we can get ready to update TypeScript peer and devDependencies.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
