### PR TITLE
Assignments: Fix `started_at` Regression

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -270,7 +270,9 @@ async function startAssignment(id: number, started_at?: WKDatableString | Date):
   let payload: WKAssignmentPayload = {};
   if (typeof started_at !== "undefined" && (isWKDatableString(started_at) || started_at instanceof Date)) {
     payload = {
-      started_at,
+      assignment: {
+        started_at,
+      },
     };
   }
   const request = new WKRequestFactory({ apiToken: WANIKANI_API_TOKEN, revision: WK_API_REVISION }).assignments.start(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bachmacintosh/wanikani-api-types",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Regularly updated type definitions for the WaniKani API",
   "keywords": [
     "wanikani",

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -209,7 +209,12 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
  */
 export interface WKAssignmentPayload {
   /**
-   * When the assignment was started. Must be greater than or equal to the assignment's `unlocked_at` date.
+   * Optionally specify properties of the Assignment; currently only `started_at` is supported.
    */
-  started_at?: Date | WKDatableString;
+  assignment?: {
+    /**
+     * When the assignment was started. Must be greater than or equal to the assignment's `unlocked_at` date.
+     */
+    started_at: Date | WKDatableString;
+  };
 }

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -209,12 +209,12 @@ export interface WKAssignmentParameters extends WKCollectionParameters {
  */
 export interface WKAssignmentPayload {
   /**
-   * Optionally specify properties of the Assignment; currently only `started_at` is supported.
+   * Specify properties of the Assignment; currently only `started_at` is supported.
    */
-  assignment?: {
+  assignment: {
     /**
      * When the assignment was started. Must be greater than or equal to the assignment's `unlocked_at` date.
      */
-    started_at: Date | WKDatableString;
+    started_at?: Date | WKDatableString;
   };
 }

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -845,7 +845,9 @@ export function validatePayload<T extends keyof WKPayloadMap>(type: T, payload: 
 
   /* Create required dummy parameters */
   const assignmentStartPayload: Required<WKAssignmentPayload> = {
-    started_at: new Date(),
+    assignment: {
+      started_at: new Date(),
+    },
   };
   const reviewCreatePayloadAssignment: Required<WKReviewPayload> = {
     review: {

--- a/tests/base/validatePayload.test.ts
+++ b/tests/base/validatePayload.test.ts
@@ -6,7 +6,9 @@ import type { WKReviewPayload } from "../../src/reviews/v20170710";
 import { validatePayload } from "../../src/base/v20170710";
 
 const assignmentStartPayload: Required<WKAssignmentPayload> = {
-  started_at: new Date(),
+  assignment: {
+    started_at: new Date(),
+  },
 };
 const reviewCreatePayloadAssignment: Required<WKReviewPayload> = {
   review: {

--- a/tests/requests/WKRequestFactory.test.ts
+++ b/tests/requests/WKRequestFactory.test.ts
@@ -93,10 +93,12 @@ it("Returns PUT request for starting an Assignment", () => {
     "Content-Type": "application/json",
     "X-Forwarded-For": "192.168.1.1",
   };
-  const expectedBody = `{"started_at":"2023-02-04T15:30:00.000Z"}`;
+  const expectedBody = `{"assignment":{"started_at":"2023-02-04T15:30:00.000Z"}}`;
 
   const payload: WKAssignmentPayload = {
-    started_at: new Date("2023-02-04T15:30:00.000Z"),
+    assignment: {
+      started_at: new Date("2023-02-04T15:30:00.000Z"),
+    },
   };
 
   const request = wanikani.assignments.start(123, payload, putPostOptions);


### PR DESCRIPTION
# Description

This PR fixes `WKAssignmentPayload` which incorrectly had the `started_at` property at its root instead of under 

# Related Issue(s) / Pull Request(s)

Related to upstream WaniKani API documentation issue

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

We're releasing this as a patch version as it's a regression based on a documentation error.

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
