### PR TITLE
GitHub: Add TypeScript 5.6 and 5.7 to Pull Request Tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -79,3 +79,11 @@ jobs:
         run: 'pnpm add --save-dev typescript@"~5.5"'
       - name: Build Library on TypeScript 5.5
         run: pnpm build
+      - name: Install TypeScript 5.6
+        run: 'pnpm add --save-dev typescript@"~5.6"'
+      - name: Build Library on TypeScript 5.6
+        run: pnpm build
+      - name: Install TypeScript 5.7
+        run: 'pnpm add --save-dev typescript@"~5.7"'
+      - name: Build Library on TypeScript 5.7
+        run: pnpm build


### PR DESCRIPTION
# Description

This PR adds TypeScript 5.6 and 5.7 to our PR tests to make sure there's no regressions in the latest TS versions.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
