### PR TITLE
Docs: Add Typedoc Plugin for New Schema Types

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -2,6 +2,7 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/v20170710.ts", "./src/index.ts"],
   "out": "docs",
+  "plugin": ["./typedoc/plugin.js"],
   "sourceLinkTemplate": "https://github.com/bachmacintosh/wanikani-api-types/blob/{gitRevision}/{path}#L{line}",
   "cleanOutputDir": true,
   "includeVersion": true,

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -1,0 +1,113 @@
+/*
+This code was adapted from: https://github.com/mkljczk/typedoc-plugin-valibot
+The above repository was forked from: https://github.com/Gerrit0/typedoc-plugin-zod
+
+The forked code was licensed under the MIT License.
+
+Copyright 2023 Gerrit Birkeland
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+*/
+
+// @ts-check
+import {
+  Comment,
+  Converter,
+  DeclarationReflection,
+  ReferenceType,
+  ReflectionKind,
+  TypeScript,
+  makeRecursiveVisitor,
+} from "typedoc";
+/** @typedef { import("typedoc").Application } Application */
+/** @typedef { import("typedoc").Context } Context */
+
+/**
+ * @param {Application} app
+ */
+export function load(app) {
+  /** @type Map<DeclarationReflection, ReferenceType> */
+  const schemaTypes = new Map();
+
+  app.converter.on(Converter.EVENT_CREATE_DECLARATION, onCreateDeclaration);
+  app.converter.on(Converter.EVENT_END, (context) => {
+    const typeCleanup = makeRecursiveVisitor({
+      reflection: (type) => {
+        context.project.removeReflection(type.declaration);
+      },
+    });
+
+    for (const [inferredType, refOrig] of schemaTypes) {
+      if (refOrig.reflection instanceof DeclarationReflection && refOrig.reflection.type instanceof ReferenceType) {
+        refOrig.reflection.type.typeArguments?.forEach((t) => t.visit(typeCleanup));
+        refOrig.reflection.type.typeArguments = [
+          ReferenceType.createResolvedReference(inferredType.name, inferredType, context.project),
+        ];
+
+        inferredType.comment ??= refOrig.reflection.comment?.clone();
+      }
+    }
+
+    schemaTypes.clear();
+  });
+
+  /**
+   * @param {Context} context
+   * @param {DeclarationReflection} refl
+   */
+  function onCreateDeclaration(context, refl) {
+    // Remove any Valibot schemas from the documentation by adding @ignore tags
+    if (refl.kindOf(ReflectionKind.Variable) && refl.type?.type === "reference" && refl.type.package === "valibot") {
+      refl.comment = new Comment([], [], new Set(["@ignore"]));
+    }
+
+    // Walks through any Valibot InferOutput type aliases, and pulls the actual type
+    if (
+      refl.kindOf(ReflectionKind.TypeAlias) &&
+      refl.type?.type === "reference" &&
+      refl.type.package === "valibot" &&
+      refl.type.qualifiedName === "InferOutput"
+    ) {
+      const originalRef = refl.type.typeArguments?.[0]?.visit({
+        query: (t) => t.queryType,
+      });
+
+      const declaration = refl.project
+        .getSymbolFromReflection(refl)
+        ?.getDeclarations()
+        ?.find(TypeScript.isTypeAliasDeclaration);
+      if (!declaration) return;
+
+      const type = context.getTypeAtLocation(declaration);
+      refl.type.visit(
+        makeRecursiveVisitor({
+          reflection: (reflectionType) => {
+            context.project.removeReflection(reflectionType.declaration);
+          },
+        }),
+      );
+      refl.type = context.converter.convertType(context, type);
+
+      if (originalRef) {
+        schemaTypes.set(refl, originalRef);
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Description

This PR adds a modified Typedoc plugin which will ignore any Valibot schema definitions, and will visit any `InferOutput` type declarations to get their actual types, improving documentation display.

# Related Issue(s) / Pull Request(s)

e.g. `Closes #123` to close a related issue, or `See #456` to reference an existing issue or PR

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
