### PR TITLE
BREAKING: Rename `WKApiRevision` and `WK_API_REVISION`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,13 +11,16 @@ export default tseslint.config(
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
   ...tseslint.configs.stylisticTypeChecked,
-  bachmanDev({ language: "typescript" }),
+  bachmanDev({ language: "typescript", namingConvention: "allow-pascal-case-constants" }),
   {
     languageOptions: {
       parserOptions: {
         projectService: true,
         tsconfigRootDir: import.meta.dirname,
       },
+    },
+    rules: {
+      "id-length": ["error", { exceptions: ["v"] }],
     },
   },
   {

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -46,14 +46,12 @@ import type { WKUserData, WKUserPreferences, WKUserPreferencesPayload } from "..
 import type { WKVoiceActor, WKVoiceActorData, WKVoiceActorParameters } from "../voice-actors/v20170710.js";
 import type { WKSummaryData } from "../summary/v20170710.js";
 
-/**
- * All known WaniKani API revisions, created when breaking changes are introduced to the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
- * @category Base
- */
+export const ApiRevision = v.pipe(
+  v.literal("20170710"),
+  v.description("All known WaniKani API revisions, created when breaking changes are introduced to the WaniKani API."),
+  v.metadata({ link: "https://docs.api.wanikani.com/20170710/#revisions-aka-versioning", categories: ["Base"] }),
+);
 export type ApiRevision = v.InferOutput<typeof ApiRevision>;
-export const ApiRevision = v.literal("20170710");
 
 /**
  * A constant representing the WaniKani API revision. This will match the revision module being imported from, or the
@@ -62,7 +60,7 @@ export const ApiRevision = v.literal("20170710");
  * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
  * @category Base
  */
-export const WK_API_REVISION: ApiRevision = "20170710";
+export const API_REVISION: ApiRevision = "20170710";
 
 /**
  * The common properties across all Collection items from the WaniKani API.

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -1,3 +1,4 @@
+import * as v from "valibot";
 import { type Brand, type NumberRange, isValidDate } from "../internal/index.js";
 import type {
   WKAssignment,
@@ -51,7 +52,8 @@ import type { WKSummaryData } from "../summary/v20170710.js";
  * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
  * @category Base
  */
-export type WKApiRevision = "20170710";
+export type ApiRevision = v.InferOutput<typeof ApiRevision>;
+export const ApiRevision = v.literal("20170710");
 
 /**
  * A constant representing the WaniKani API revision. This will match the revision module being imported from, or the
@@ -60,7 +62,7 @@ export type WKApiRevision = "20170710";
  * @see {@link https://docs.api.wanikani.com/20170710/#revisions-aka-versioning}
  * @category Base
  */
-export const WK_API_REVISION: WKApiRevision = "20170710";
+export const WK_API_REVISION: ApiRevision = "20170710";
 
 /**
  * The common properties across all Collection items from the WaniKani API.

--- a/src/requests/v20170710.ts
+++ b/src/requests/v20170710.ts
@@ -1,4 +1,4 @@
-import { type WKApiRevision, stringifyParameters, validateParameters, validatePayload } from "../base/v20170710.js";
+import { type ApiRevision, stringifyParameters, validateParameters, validatePayload } from "../base/v20170710.js";
 import type { WKAssignmentParameters, WKAssignmentPayload } from "../assignments/v20170710.js";
 import type { WKReviewParameters, WKReviewPayload } from "../reviews/v20170710.js";
 import type {
@@ -624,7 +624,7 @@ export class WKRequestFactory {
    * @param revision The WaniKani API Revision to use.
    * @returns The factory, with the newly set WaniKani API Revision.
    */
-  public setApiRevision(revision: WKApiRevision): this {
+  public setApiRevision(revision: ApiRevision): this {
     this._initHeaders["Wanikani-Revision"] = revision;
     this._getHeaders["Wanikani-Revision"] = revision;
     this._postPutHeaders["Wanikani-Revision"] = revision;
@@ -675,7 +675,7 @@ export interface WKRequestFactoryInit {
   /**
    * The WaniKani API Revision to use in the requests; if not set, the factory will default to the current API Revision.
    */
-  revision?: WKApiRevision;
+  revision?: ApiRevision;
 }
 
 /**
@@ -701,7 +701,7 @@ export interface WKRequestHeaders {
   /** HTTP Authorization header, using a Bearer Token. */
   Authorization: `Bearer ${string}`;
   /** The WaniKani API Revision. */
-  "Wanikani-Revision": WKApiRevision;
+  "Wanikani-Revision": ApiRevision;
   [customHeaders: string]: string;
   /** The client should accept JSON as that is how the WaniKani API's response bodies are formatted. */
   Accept?: "application/json";

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -29,6 +29,7 @@ SOFTWARE.
 // @ts-check
 import {
   Comment,
+  CommentTag,
   Converter,
   DeclarationReflection,
   ReferenceType,
@@ -46,6 +47,9 @@ export function load(app) {
   /** @type Map<DeclarationReflection, ReferenceType> */
   const schemaTypes = new Map();
 
+  /** @type Map<string, Comment | undefined> */
+  const schemaComments = new Map();
+
   app.converter.on(Converter.EVENT_CREATE_DECLARATION, onCreateDeclaration);
   app.converter.on(Converter.EVENT_END, (context) => {
     const typeCleanup = makeRecursiveVisitor({
@@ -60,8 +64,6 @@ export function load(app) {
         refOrig.reflection.type.typeArguments = [
           ReferenceType.createResolvedReference(inferredType.name, inferredType, context.project),
         ];
-
-        inferredType.comment ??= refOrig.reflection.comment?.clone();
       }
     }
 
@@ -74,7 +76,82 @@ export function load(app) {
    */
   function onCreateDeclaration(context, refl) {
     // Remove any Valibot schemas from the documentation by adding @ignore tags
-    if (refl.kindOf(ReflectionKind.Variable) && refl.type?.type === "reference" && refl.type.package === "valibot") {
+    if (
+      (refl.kindOf(ReflectionKind.Variable) || refl.kindOf(ReflectionKind.Property)) &&
+      refl.type?.type === "reference" &&
+      refl.type.package === "valibot"
+    ) {
+      if (refl.type.qualifiedName === "SchemaWithPipe") {
+        refl.type.typeArguments?.forEach((typeArgument) => {
+          if (typeArgument.type === "tuple") {
+            typeArgument.elements.forEach((element) => {
+              if (element.type === "reference" && typeof element.typeArguments !== "undefined") {
+                if (
+                  element.qualifiedName === "DescriptionAction" &&
+                  typeof element.typeArguments[1] !== "undefined" &&
+                  element.typeArguments[1].type === "literal" &&
+                  typeof element.typeArguments[1].value === "string"
+                ) {
+                  if (typeof refl.comment === "undefined") {
+                    refl.comment = new Comment([{ kind: "text", text: element.typeArguments[1].value }]);
+                  } else {
+                    refl.comment.summary = [{ kind: "text", text: element.typeArguments[1].value }];
+                  }
+                } else if (
+                  element.qualifiedName === "MetadataAction" &&
+                  typeof element.typeArguments[1] !== "undefined" &&
+                  element.typeArguments[1].type === "reflection"
+                ) {
+                  element.typeArguments[1].declaration.children?.forEach((child) => {
+                    if (child.name === "link" && typeof child.defaultValue === "string") {
+                      if (typeof refl.comment === "undefined") {
+                        refl.comment = new Comment(
+                          [],
+                          [
+                            new CommentTag("@see", [
+                              { kind: "inline-tag", tag: "@link", text: child.defaultValue.replaceAll(`"`, "") },
+                            ]),
+                          ],
+                        );
+                      } else {
+                        refl.comment.blockTags.push(
+                          new CommentTag("@see", [
+                            { kind: "inline-tag", tag: "@link", text: child.defaultValue.replaceAll(`"`, "") },
+                          ]),
+                        );
+                      }
+                    } else if (
+                      child.name === "categories" &&
+                      child.type?.type === "typeOperator" &&
+                      child.type.target.type === "tuple"
+                    ) {
+                      child.type.target.elements.forEach((category) => {
+                        if (category.type === "literal" && typeof category.value === "string") {
+                          if (typeof refl.comment === "undefined") {
+                            refl.comment = new Comment(
+                              [],
+                              [
+                                new CommentTag("@category", [
+                                  { kind: "text", text: category.value.replaceAll(`"`, "") },
+                                ]),
+                              ],
+                            );
+                          } else {
+                            refl.comment.blockTags.push(
+                              new CommentTag("@category", [{ kind: "text", text: category.value.replaceAll(`"`, "") }]),
+                            );
+                          }
+                        }
+                      });
+                    }
+                  });
+                }
+              }
+            });
+          }
+        });
+      }
+      schemaComments.set(refl.name, refl.comment);
       refl.comment = new Comment([], [], new Set(["@ignore"]));
     }
 
@@ -104,6 +181,8 @@ export function load(app) {
         }),
       );
       refl.type = context.converter.convertType(context, type);
+
+      refl.comment = schemaComments.get(refl.name);
 
       if (originalRef) {
         schemaTypes.set(refl, originalRef);

--- a/typedoc/plugin.js
+++ b/typedoc/plugin.js
@@ -76,11 +76,7 @@ export function load(app) {
    */
   function onCreateDeclaration(context, refl) {
     // Remove any Valibot schemas from the documentation by adding @ignore tags
-    if (
-      (refl.kindOf(ReflectionKind.Variable) || refl.kindOf(ReflectionKind.Property)) &&
-      refl.type?.type === "reference" &&
-      refl.type.package === "valibot"
-    ) {
+    if (refl.kindOf(ReflectionKind.Variable) && refl.type?.type === "reference" && refl.type.package === "valibot") {
       if (refl.type.qualifiedName === "SchemaWithPipe") {
         refl.type.typeArguments?.forEach((typeArgument) => {
           if (typeArgument.type === "tuple") {


### PR DESCRIPTION
# Description

This PR renames and retypes `WKApiRevision` into `ApiRevision`, and renames `WK_API_REVISION` to `API_REVISION`. We also made some changes to the Typedoc plugin to pick up information described on the Valibot schema description and metadata.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [x] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
