### PR TITLE
Chore: Update TypeScript Configuration

### DIFF
--- a/src/requests/v20170710.ts
+++ b/src/requests/v20170710.ts
@@ -690,7 +690,7 @@ export interface ApiRequestHeaders {
   authorization: `Bearer ${string}`;
   /** The WaniKani API Revision. */
   "wanikani-revision": ApiRevision;
-  [customHeaders: string]: string;
+  [customHeaders: string]: string | undefined;
   /** The client should accept JSON as that is how the WaniKani API's response bodies are formatted. */
   accept?: "application/json";
   /** When making a POST or PUT request, the client should indicate they are sending a JSON request body. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "removeComments": false,
     "target": "ES2020",
     "verbatimModuleSyntax": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": false,
+    "noUncheckedIndexedAccess": true
   },
   "include": ["src/**/*.ts", "vitest.config.ts"],
   "exclude": ["dist/**", "tests/**", "node_modules/**"]


### PR DESCRIPTION
# Description

This PR change's the project's TypeScript configuration in two ways:

1. We disabled `exactOptionalPropertyTypes`, because any data to/from WaniKani is serialized from JSON, so there isn't any real difference between a missing field and a present `undefined` field, for instance; we also guard against any `undefined` values (present or missing) using `typeof foo === "undefined"` type narrowing. This change also helps account for Valibot's changes to their `optional` schema, regardless of the outcome (TBD as of this PR)
2. We enabled `noUncheckedIndexedAccess` to account for any array index access where an item may not exist in an array; for instance, a `string[]` with two items, accessing an item at index 3 could be `undefined` -- this setting ensures TypeScript will account for it and raise a type checking error

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
