### PR TITLE
BREAKING: Rework Resource/Collection/Report Types, Add Schemas

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from "typescript-eslint";
 export default tseslint.config(
   {
     // Replace output folder if needed, e.g. "dist"
-    ignores: ["{coverage,docs,dist,tests}/**"],
+    ignores: ["{coverage,docs,dist}/**"],
   },
   eslint.configs.recommended,
   ...tseslint.configs.strictTypeChecked,
@@ -30,6 +30,13 @@ export default tseslint.config(
   {
     files: ["**/*.js"],
     ...bachmanDev({ language: "javascript-in-typescript" }),
+  },
+  {
+    files: ["tests/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-confusing-void-expression": ["off"],
+      "@typescript-eslint/no-magic-numbers": ["off"],
+    },
   },
   eslintConfigPrettier,
 );

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:docs": "typedoc",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint --fix . && prettier --write .",
-    "test": "vitest run --typecheck"
+    "test": "vitest run"
   },
   "files": [
     "dist/**/*.{js,d.ts}"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:docs": "typedoc",
     "lint": "eslint . && prettier --check .",
     "lint:fix": "eslint --fix . && prettier --write .",
-    "test": "vitest run"
+    "test": "vitest run --typecheck"
   },
   "files": [
     "dist/**/*.{js,d.ts}"

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -1,55 +1,14 @@
 import * as v from "valibot";
 import {
-  type CollectionParameters,
+  BaseCollection,
+  BaseResource,
+  CollectionParameters,
   DatableString,
   Level,
   SubjectTuple,
-  type SubjectType,
-  type WKCollection,
-  type WKResource,
+  SubjectType,
 } from "../base/v20170710.js";
 import { SpacedRepetitionSystemStageNumber } from "../spaced-repetition-systems/v20170710.js";
-import { extendCollectionParameters } from "../internal/index.js";
-
-/**
- * Assignments contain information about a user's progress on a particular subject, including their current state and
- * timestamps for various progress milestones. Assignments are created when a user has passed all the components of the
- * given subject and the assignment is at or below their current level for the first time.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#assignments}
- * @category Assignments
- * @category Resources
- */
-export interface WKAssignment extends WKResource {
-  /**
-   * Date for the returned assignment.
-   */
-  data: WKAssignmentData;
-
-  /**
-   * A unique number identifying the assignment.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "assignment";
-}
-
-/**
- * A collection of assignments returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-assignments}
- * @category Assignments
- * @category Collections
- */
-export interface WKAssignmentCollection extends WKCollection {
-  /**
-   * An array of returned assignments.
-   */
-  data: WKAssignment[];
-}
 
 /**
  * Data for assignments returned from the WaniKani API.
@@ -58,7 +17,7 @@ export interface WKAssignmentCollection extends WKCollection {
  * @category Assignments
  * @category Data
  */
-export interface WKAssignmentData {
+export interface AssignmentData {
   /**
    * When the related subject will be available in the user's review queue.
    */
@@ -106,7 +65,7 @@ export interface WKAssignmentData {
   subject_id: number;
 
   /**
-   * The type of the associated subject, one of: `kanji`, `radical`, or `vocabulary`.
+   * The type of the associated subject.
    */
   subject_type: SubjectType;
 
@@ -119,6 +78,71 @@ export interface WKAssignmentData {
    */
   unlocked_at: DatableString | null;
 }
+export const AssignmentData = v.object({
+  available_at: v.union([DatableString, v.null()]),
+  burned_at: v.union([DatableString, v.null()]),
+  created_at: DatableString,
+  hidden: v.boolean(),
+  passed_at: v.union([DatableString, v.null()]),
+  resurrected_at: v.union([DatableString, v.null()]),
+  srs_stage: SpacedRepetitionSystemStageNumber,
+  started_at: v.union([DatableString, v.null()]),
+  subject_id: v.number(),
+  subject_type: SubjectType,
+  unlocked_at: v.union([DatableString, v.null()]),
+});
+
+/**
+ * Assignments contain information about a user's progress on a particular subject, including their current state and
+ * timestamps for various progress milestones. Assignments are created when a user has passed all the components of the
+ * given subject and the assignment is at or below their current level for the first time.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#assignments}
+ * @category Assignments
+ * @category Resources
+ */
+export interface Assignment extends BaseResource {
+  /**
+   * Data for the returned assignment.
+   */
+  data: AssignmentData;
+
+  /**
+   * A unique number identifying the assignment.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "assignment";
+}
+export const Assignment = v.object({
+  ...BaseResource.entries,
+  data: AssignmentData,
+  data_updated_at: DatableString,
+  id: v.number(),
+  object: v.literal("assignment"),
+  url: v.string(),
+});
+
+/**
+ * A collection of assignments returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-assignments}
+ * @category Assignments
+ * @category Collections
+ */
+export interface AssignmentCollection extends BaseCollection {
+  /**
+   * An array of returned assignments.
+   */
+  data: Assignment[];
+}
+export const AssignmentCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Assignment),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for an
@@ -190,8 +214,7 @@ export interface AssignmentParameters extends CollectionParameters {
   subject_ids?: number[];
 
   /**
-   * Only assignments where `data.subject_type` matches one of the array values are returned. Valid values are:
-   * `radical`, `kanji`, or `vocabulary`.
+   * Only assignments where `data.subject_type` matches one of the array values are returned.
    */
   subject_types?: SubjectTuple;
 
@@ -201,23 +224,22 @@ export interface AssignmentParameters extends CollectionParameters {
    */
   unlocked?: boolean;
 }
-export const AssignmentParameters = extendCollectionParameters(
-  v.object({
-    available_after: v.optional(v.union([DatableString, v.date()])),
-    available_before: v.optional(v.union([DatableString, v.date()])),
-    burned: v.optional(v.boolean()),
-    hidden: v.optional(v.boolean()),
-    immediately_available_for_lessons: v.optional(v.boolean()),
-    immediately_available_for_review: v.optional(v.boolean()),
-    in_review: v.optional(v.boolean()),
-    levels: v.optional(v.array(Level)),
-    srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
-    started: v.optional(v.boolean()),
-    subject_ids: v.optional(v.array(v.number())),
-    subject_types: v.optional(SubjectTuple),
-    unlocked: v.optional(v.boolean()),
-  }),
-);
+export const AssignmentParameters = v.object({
+  ...CollectionParameters.entries,
+  available_after: v.optional(v.union([DatableString, v.date()])),
+  available_before: v.optional(v.union([DatableString, v.date()])),
+  burned: v.optional(v.boolean()),
+  hidden: v.optional(v.boolean()),
+  immediately_available_for_lessons: v.optional(v.boolean()),
+  immediately_available_for_review: v.optional(v.boolean()),
+  in_review: v.optional(v.boolean()),
+  levels: v.optional(v.array(Level)),
+  srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
+  started: v.optional(v.boolean()),
+  subject_ids: v.optional(v.array(v.number())),
+  subject_types: v.optional(SubjectTuple),
+  unlocked: v.optional(v.boolean()),
+});
 
 /**
  * The optional payload used in the request to start a new assignment via the WaniKani API.

--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -120,10 +120,8 @@ export interface Assignment extends BaseResource {
 export const Assignment = v.object({
   ...BaseResource.entries,
   data: AssignmentData,
-  data_updated_at: DatableString,
   id: v.number(),
   object: v.literal("assignment"),
-  url: v.string(),
 });
 
 /**

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -241,9 +241,7 @@ export const CollectionParameters = v.object({
  * @category Base
  */
 export function stringifyParameters(params: CollectionParameters): string {
-  if (typeof params !== "object") {
-    throw new TypeError("Parameters must be expressed as an object.");
-  }
+  v.assert(CollectionParameters, params);
   if (Object.keys(params).length === 0) {
     return "";
   }

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -321,3 +321,7 @@ export interface ApiError {
    */
   error: string;
 }
+export const ApiError = v.object({
+  code: v.number(),
+  error: v.string(),
+});

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -1,25 +1,4 @@
 import * as v from "valibot";
-import type { WKAssignment, WKAssignmentData } from "../assignments/v20170710.js";
-import type {
-  WKKanaVocabulary,
-  WKKanaVocabularyData,
-  WKKanji,
-  WKKanjiData,
-  WKRadical,
-  WKRadicalData,
-  WKSubject,
-  WKVocabulary,
-  WKVocabularyData,
-} from "../subjects/v20170710.js";
-import type { WKLevelProgression, WKLevelProgressionData } from "../level-progressions/v20170710.js";
-import type { WKReset, WKResetData } from "../resets/v20170710.js";
-import type { WKReview, WKReviewData } from "../reviews/v20170710.js";
-import type { WKReviewStatistic, WKReviewStatisticData } from "../review-statistics/v20170710.js";
-import type { WKSpacedRepetitionSystem, WKSpacedRepetitionSystemData } from "../spaced-repetition-systems/v20170710.js";
-import type { WKStudyMaterial, WKStudyMaterialData } from "../study-materials/v20170710.js";
-import type { WKVoiceActor, WKVoiceActorData } from "../voice-actors/v20170710.js";
-import type { WKSummaryData } from "../summary/v20170710.js";
-import type { WKUserData } from "../user/v20170710.js";
 
 /**
  * All known WaniKani API revisions, created when breaking changes are introduced to the WaniKani API.
@@ -48,27 +27,26 @@ export type DatableString = v.Brand<"DatableString"> & string;
 export const DatableString = v.pipe(v.string(), v.isoTimestamp(), v.brand("DatableString"));
 
 /**
- * A number representing a level in WaniKani, from `1` to `60`.
- *
- * @category Base
- */
-export type Level = number & {};
-const MaxLevel = 60;
-export const Level = v.pipe(v.number(), v.minValue(1), v.maxValue(MaxLevel));
-
-/**
  * The minimum level provided by WaniKani; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-export const MIN_LEVEL: Level = v.parse(Level, 1);
+export const MIN_LEVEL = 1;
 
 /**
  * The maximum level provided by WaniKani; exported for use in lieu of a Magic Number.
  *
  * @category Base
  */
-export const MAX_LEVEL: Level = v.parse(Level, MaxLevel);
+export const MAX_LEVEL = 60;
+
+/**
+ * A number representing a level in WaniKani, from `1` to `60`.
+ *
+ * @category Base
+ */
+export type Level = number & {};
+export const Level = v.pipe(v.number(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
 
 /**
  * The types of resources used on WaniKani and its API.
@@ -126,31 +104,41 @@ export const SubjectTuple = v.pipe(
 );
 
 /**
+ * The common properties across all Resources from the WaniKani API.
+ *
+ * @remarks This is a partial interface; most use cases involve using a reource that extends it.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
+ *
+ * @category Base
+ * @category Resources
+ */
+export interface BaseResource {
+  /**
+   * For a resource, this is the last time that particular resource was updated.
+   */
+  data_updated_at: DatableString;
+
+  /**
+   * The URL of the requested resource.
+   */
+  url: string;
+}
+export const BaseResource = v.object({
+  data_updated_at: DatableString,
+  url: v.string(),
+});
+
+/**
  * The common properties across all Collection items from the WaniKani API.
+ *
+ * @remarks This is a partial interface; most use cases involve using a reource that extends it.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
  * @category Base
  * @category Collections
  */
-export interface WKCollection {
-  /**
-   * The resource's data, dependent on the collection's resource type.
-   */
-  data:
-    | WKAssignment[]
-    | WKKanaVocabulary[]
-    | WKKanji[]
-    | WKLevelProgression[]
-    | WKRadical[]
-    | WKReset[]
-    | WKReview[]
-    | WKReviewStatistic[]
-    | WKSpacedRepetitionSystem[]
-    | WKStudyMaterial[]
-    | WKSubject[]
-    | WKVocabulary[]
-    | WKVoiceActor[];
-
+export interface BaseCollection {
   /**
    * For collections, this is the timestamp of the most recently updated resource in the specified scope and is not
    * limited by pagination. If no items were returned for the specified scope, then this will be `null`.
@@ -192,17 +180,18 @@ export interface WKCollection {
    * The URL of the request. For collections, that will contain all the filters and options you've passed to the API.
    */
   url: string;
-
-  /**
-   * A collection will never have a `code` property.
-   */
-  code?: never;
-
-  /**
-   * A collection will never have an `error` property.
-   */
-  error?: never;
 }
+export const BaseCollection = v.object({
+  data_updated_at: v.union([DatableString, v.null()]),
+  object: v.literal("collection"),
+  pages: v.object({
+    next_url: v.union([v.string(), v.null()]),
+    per_page: v.number(),
+    previous_url: v.union([v.string(), v.null()]),
+  }),
+  total_count: v.number(),
+  url: v.string(),
+});
 
 /**
  * Query string parameters that can be sent to any WaniKani API collection endpoint.
@@ -242,157 +231,6 @@ export const CollectionParameters = v.object({
   page_before_id: v.optional(v.number()),
   updated_after: v.optional(v.union([DatableString, v.date()])),
 });
-
-/**
- * An error response returned by the WaniKani API.
- *
- * @category Base
- */
-export interface WKError {
-  /**
-   * An HTTP status code indicating the type of error.
-   */
-  code: number;
-
-  /**
-   * A message string that describes the error.
-   */
-  error: string;
-
-  /**
-   * An error will never include a `data` property.
-   */
-  data?: never;
-
-  /**
-   * An error will never include a `data_updated_at` property.
-   */
-  data_updated_at?: never;
-
-  /**
-   * An error will never include an `id` property.
-   */
-  id?: never;
-
-  /**
-   * An error will never include an `object` property.
-   */
-  object?: never;
-
-  /**
-   * An error will never include a `pages` property.
-   */
-  pages?: never;
-
-  /**
-   * An error will never include a `total_count` property.
-   */
-  total_count?: never;
-
-  /**
-   * An error will never include a `url` property.
-   */
-  url?: never;
-}
-
-/**
- * The common properties across all Reports from the WaniKani API
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
- *
- * @category Base
- * @category Reports
- */
-export interface WKReport {
-  /**
-   * The report's data, dependent on the particular report.
-   */
-  data: WKSummaryData;
-
-  /**
-   * The last time the report was updated.
-   */
-  data_updated_at: DatableString;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "report";
-
-  /**
-   * The URL of the requested report.
-   */
-  url: string;
-
-  /**
-   * A report will never have a `code` property.
-   */
-  code?: never;
-
-  /**
-   * A report will never have an `error` property.
-   */
-  error?: never;
-}
-
-/**
- * The common properties across all Resources from the WaniKani API
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
- *
- * @category Base
- * @category Resources
- */
-export interface WKResource {
-  /**
-   * The resource's data, dependent on the particular type of resource.
-   */
-  data:
-    | WKAssignmentData
-    | WKKanaVocabularyData
-    | WKKanjiData
-    | WKLevelProgressionData
-    | WKRadicalData
-    | WKResetData
-    | WKReviewData
-    | WKReviewStatisticData
-    | WKSpacedRepetitionSystemData
-    | WKStudyMaterialData
-    | WKUserData
-    | WKVocabularyData
-    | WKVoiceActorData;
-
-  /**
-   * For a resource, this is the last time that particular resource was updated.
-   */
-  data_updated_at: DatableString;
-
-  /**
-   * The kind of object returned.
-   */
-  object: ResourceType | SubjectType;
-
-  /**
-   * The URL of the requested resource.
-   */
-  url: string;
-
-  /**
-   * A resource will never have a `code` property.
-   */
-  code?: never;
-
-  /**
-   * A resource will never have an `error` property.
-   */
-  error?: never;
-
-  /**
-   * A unique identifying number present on all Resources except a User
-   * resource, where it is present the `data` object.
-   */
-  id?: number;
-}
 
 /**
  * Parses a parameter object, for use with the WaniKani API.
@@ -435,4 +273,53 @@ export function stringifyParameters(params: CollectionParameters): string {
     isFirstItem = false;
   }
   return queryString;
+}
+
+/**
+ * The common properties across all Reports from the WaniKani API
+ *
+ * @remarks This is a partial interface; most use cases involve using a reource that extends it.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#response-structure}
+ *
+ * @category Base
+ * @category Reports
+ */
+export interface BaseReport {
+  /**
+   * The last time the report was updated.
+   */
+  data_updated_at: DatableString;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "report";
+
+  /**
+   * The URL of the requested report.
+   */
+  url: string;
+}
+export const BaseReport = v.object({
+  data_updated_at: DatableString,
+  object: v.literal("report"),
+  url: v.string(),
+});
+
+/**
+ * An error response returned by the WaniKani API.
+ *
+ * @category Base
+ */
+export interface ApiError {
+  /**
+   * An HTTP status code indicating the type of error.
+   */
+  code: number;
+
+  /**
+   * A message string that describes the error.
+   */
+  error: string;
 }

--- a/src/internal/index.ts
+++ b/src/internal/index.ts
@@ -1,8 +1,0 @@
-import * as v from "valibot";
-import { CollectionParameters } from "../base/v20170710.js";
-
-export function extendCollectionParameters<
-  T extends v.ObjectSchema<v.ObjectEntries, v.ErrorMessage<v.ObjectIssue> | undefined>,
->(schema: T): v.IntersectSchema<[typeof CollectionParameters, T], undefined> {
-  return v.intersect([CollectionParameters, schema]);
-}

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -1,55 +1,5 @@
-import {
-  CollectionParameters,
-  type DatableString,
-  type Level,
-  type WKCollection,
-  type WKResource,
-} from "../base/v20170710.js";
-
-/**
- * Level progressions contain information about a user's progress through the WaniKani levels.
- *
- * A level progression is created when a user has met the prerequisites for leveling up, which are:
- *
- * * Reach a 90% passing rate on assignments for a user's current level with a `subject_type` of `kanji`. Passed
- * assignments have `data.passed` equal to `true` and a `data.passed_at` that's in the past.
- * * Have access to the level. Under `/user`, the `data.level` must be less than or equal to
- * `data.subscription.max_level_granted`.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#level-progressions}
- * @category Level Progressions
- * @category Resources
- */
-export interface WKLevelProgression extends WKResource {
-  /**
-   * Data for the returned level progression.
-   */
-  data: WKLevelProgressionData;
-
-  /**
-   * A unique number identifying the level progression.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "level_progression";
-}
-
-/**
- * A collection of level progressions returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-level-progressions}
- * @category Collections
- * @category Level Progressions
- */
-export interface WKLevelProgressionCollection extends WKCollection {
-  /**
-   * An array of returned level progressions.
-   */
-  data: WKLevelProgression[];
-}
+import * as v from "valibot";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level } from "../base/v20170710.js";
 
 /**
  * Data for level progressions returned from the WaniKani API.
@@ -58,7 +8,7 @@ export interface WKLevelProgressionCollection extends WKCollection {
  * @category Data
  * @category Level Progressions
  */
-export interface WKLevelProgressionData {
+export interface LevelProgressionData {
   /**
    * Timestamp when the user abandons the level. This is primarily used when the user initiates a reset.
    */
@@ -95,6 +45,70 @@ export interface WKLevelProgressionData {
    */
   unlocked_at: DatableString | null;
 }
+export const LevelProgressionData = v.object({
+  abandoned_at: v.union([DatableString, v.null()]),
+  completed_at: v.union([DatableString, v.null()]),
+  created_at: DatableString,
+  level: Level,
+  passed_at: v.union([DatableString, v.null()]),
+  started_at: v.union([DatableString, v.null()]),
+  unlocked_at: v.union([DatableString, v.null()]),
+});
+
+/**
+ * Level progressions contain information about a user's progress through the WaniKani levels.
+ *
+ * A level progression is created when a user has met the prerequisites for leveling up, which are:
+ *
+ * * Reach a 90% passing rate on assignments for a user's current level with a `subject_type` of `kanji`. Passed
+ * assignments have `data.passed` equal to `true` and a `data.passed_at` that's in the past.
+ * * Have access to the level. Under `/user`, the `data.level` must be less than or equal to
+ * `data.subscription.max_level_granted`.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#level-progressions}
+ * @category Level Progressions
+ * @category Resources
+ */
+export interface LevelProgression extends BaseResource {
+  /**
+   * Data for the returned level progression.
+   */
+  data: LevelProgressionData;
+
+  /**
+   * A unique number identifying the level progression.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "level_progression";
+}
+export const LevelProgression = v.object({
+  ...BaseResource.entries,
+  data: LevelProgressionData,
+  id: v.number(),
+  object: v.literal("level_progression"),
+});
+
+/**
+ * A collection of level progressions returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-level-progressions}
+ * @category Collections
+ * @category Level Progressions
+ */
+export interface LevelProgressionCollection extends BaseCollection {
+  /**
+   * An array of returned level progressions.
+   */
+  data: LevelProgression[];
+}
+export const LevelProgressionCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(LevelProgression),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Level Progression Collection.

--- a/src/requests/v20170710.ts
+++ b/src/requests/v20170710.ts
@@ -66,8 +66,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(AssignmentParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(AssignmentParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -80,7 +80,7 @@ export class ApiRequestFactory {
      * @returns A Start Assignment Request usable in any HTTP API/Library.
      */
     start: (assignmentId: number, payload: AssignmentPayload, options?: ApiRequestOptions): ApiRequest => {
-      const validatedPayload = v.parse(AssignmentPayload, payload);
+      v.assert(AssignmentPayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options?.customHeaders !== "undefined") {
         for (const [key, value] of Object.entries(options.customHeaders)) {
@@ -89,7 +89,7 @@ export class ApiRequestFactory {
         }
       }
       const request: ApiRequest = {
-        body: JSON.stringify(validatedPayload),
+        body: JSON.stringify(payload),
         headers,
         method: "PUT",
         url: `${this.baseUrl}/assignments/${assignmentId}/start`,
@@ -129,8 +129,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(LevelProgressionParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(LevelProgressionParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -163,8 +163,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(ResetParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(ResetParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -198,8 +198,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(ReviewStatisticParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(ReviewStatisticParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -216,7 +216,7 @@ export class ApiRequestFactory {
      * @returns A Create Review Request usabile in any HTTP API/Library.
      */
     create: (payload: ReviewPayload, options?: ApiRequestOptions): ApiRequest => {
-      const validatedPayload = v.parse(ReviewPayload, payload);
+      v.assert(ReviewPayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
         if (typeof options.customHeaders !== "undefined") {
@@ -227,7 +227,7 @@ export class ApiRequestFactory {
         }
       }
       const request: ApiRequest = {
-        body: JSON.stringify(validatedPayload),
+        body: JSON.stringify(payload),
         headers,
         method: "POST",
         url: `${this.baseUrl}/reviews`,
@@ -258,8 +258,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(ReviewParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(ReviewParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -293,8 +293,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(SpacedRepetitionSystemParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(SpacedRepetitionSystemParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -328,8 +328,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(StudyMaterialParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(StudyMaterialParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -341,7 +341,7 @@ export class ApiRequestFactory {
      * @returns A Create Study Material Request usabile in any HTTP API/Library.
      */
     create: (payload: StudyMaterialCreatePayload, options?: ApiRequestOptions): ApiRequest => {
-      const validatedPayload = v.parse(StudyMaterialCreatePayload, payload);
+      v.assert(StudyMaterialCreatePayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
         if (typeof options.customHeaders !== "undefined") {
@@ -352,7 +352,7 @@ export class ApiRequestFactory {
         }
       }
       const request: ApiRequest = {
-        body: JSON.stringify(validatedPayload),
+        body: JSON.stringify(payload),
         headers,
         method: "POST",
         url: `${this.baseUrl}/study_materials`,
@@ -368,7 +368,7 @@ export class ApiRequestFactory {
      * @returns An Update Study Material Request usabile in any HTTP API/Library.
      */
     update: (studyMaterialId: number, payload: StudyMaterialUpdatePayload, options?: ApiRequestOptions): ApiRequest => {
-      const validatedPayload = v.parse(StudyMaterialUpdatePayload, payload);
+      v.assert(StudyMaterialUpdatePayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
         if (typeof options.customHeaders !== "undefined") {
@@ -379,7 +379,7 @@ export class ApiRequestFactory {
         }
       }
       const request: ApiRequest = {
-        body: JSON.stringify(validatedPayload),
+        body: JSON.stringify(payload),
         headers,
         method: "PUT",
         url: `${this.baseUrl}/study_materials/${studyMaterialId}`,
@@ -415,8 +415,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(SubjectParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(SubjectParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },
@@ -485,7 +485,7 @@ export class ApiRequestFactory {
      * @returns An Update User Preferences Request usabile in any HTTP API/Library.
      */
     updatePreferences: (payload: UserPreferencesPayload, options?: ApiRequestOptions): ApiRequest => {
-      const validatedPayload = v.parse(UserPreferencesPayload, payload);
+      v.assert(UserPreferencesPayload, payload);
       const headers = { ...this._postPutHeaders };
       if (typeof options !== "undefined") {
         if (typeof options.customHeaders !== "undefined") {
@@ -496,7 +496,7 @@ export class ApiRequestFactory {
         }
       }
       const request: ApiRequest = {
-        body: JSON.stringify(validatedPayload),
+        body: JSON.stringify(payload),
         headers,
         method: "PUT",
         url: `${this.baseUrl}/user`,
@@ -532,8 +532,8 @@ export class ApiRequestFactory {
       if (typeof idOrParams === "number") {
         request.url += `/${idOrParams}`;
       } else if (typeof idOrParams !== "undefined") {
-        const validatedParameters = v.parse(VoiceActorParameters, idOrParams);
-        request.url += stringifyParameters(validatedParameters);
+        v.assert(VoiceActorParameters, idOrParams);
+        request.url += stringifyParameters(idOrParams);
       }
       return request;
     },

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -1,51 +1,5 @@
-import {
-  CollectionParameters,
-  type DatableString,
-  type Level,
-  type WKCollection,
-  type WKResource,
-} from "../base/v20170710.js";
-
-/**
- * Users can reset their progress back to any level at or below their current level. When they reset to a particular
- * level, all of the assignments and review_statistics at that level or higher are set back to their default state.
- *
- * Resets contain information about when those resets happen, the starting level, and the target level.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#resets}
- * @category Resets
- * @category Resources
- */
-export interface WKReset extends WKResource {
-  /**
-   * Data for the returned reset.
-   */
-  data: WKResetData;
-
-  /**
-   * A unique number identifying the reset.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "reset";
-}
-
-/**
- * A collection of resets returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-resets}
- * @category Collections
- * @category Resets
- */
-export interface WKResetCollection extends WKCollection {
-  /**
-   * An array of returned resets.
-   */
-  data: WKReset[];
-}
+import * as v from "valibot";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level } from "../base/v20170710.js";
 
 /**
  * Data for resets returned from the WaniKani API.
@@ -54,7 +8,7 @@ export interface WKResetCollection extends WKCollection {
  * @category Data
  * @category Resets
  */
-export interface WKResetData {
+export interface ResetData {
   /**
    * Timestamp when the user confirmed the reset.
    */
@@ -75,6 +29,63 @@ export interface WKResetData {
    */
   target_level: Level;
 }
+export const ResetData = v.object({
+  confirmed_at: v.union([DatableString, v.null()]),
+  created_at: DatableString,
+  original_level: Level,
+  target_level: Level,
+});
+
+/**
+ * Users can reset their progress back to any level at or below their current level. When they reset to a particular
+ * level, all of the assignments and review_statistics at that level or higher are set back to their default state.
+ *
+ * Resets contain information about when those resets happen, the starting level, and the target level.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#resets}
+ * @category Resets
+ * @category Resources
+ */
+export interface Reset extends BaseResource {
+  /**
+   * Data for the returned reset.
+   */
+  data: ResetData;
+
+  /**
+   * A unique number identifying the reset.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "reset";
+}
+export const Reset = v.object({
+  ...BaseResource.entries,
+  data: ResetData,
+  id: v.number(),
+  object: v.literal("reset"),
+});
+
+/**
+ * A collection of resets returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-resets}
+ * @category Collections
+ * @category Resets
+ */
+export interface ResetCollection extends BaseCollection {
+  /**
+   * An array of returned resets.
+   */
+  data: Reset[];
+}
+export const ResetCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Reset),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Reset Collection.

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -1,55 +1,12 @@
 import * as v from "valibot";
 import {
-  type CollectionParameters,
-  type DatableString,
+  BaseCollection,
+  BaseResource,
+  CollectionParameters,
+  DatableString,
   SubjectTuple,
-  type SubjectType,
-  type WKCollection,
-  type WKResource,
+  SubjectType,
 } from "../base/v20170710.js";
-import { extendCollectionParameters } from "../internal/index.js";
-
-/**
- * Review statistics summarize the activity recorded in reviews. They contain sum the number of correct and incorrect
- * answers for both meaning and reading. They track current and maximum streaks of correct answers. They store the
- * overall percentage of correct answers versus total answers.
- *
- * A review statistic is created when the user has done their first review on the related subject.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#review-statistics}
- * @category Resources
- * @category Review Statistics
- */
-export interface WKReviewStatistic extends WKResource {
-  /**
-   * Data for the returned review statistic.
-   */
-  data: WKReviewStatisticData;
-
-  /**
-   * A unique number identifying the review statistic.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "review_statistic";
-}
-
-/**
- * A collection of review statistics returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-review-statistics}
- * @category Collections
- * @category Review Statistics
- */
-export interface WKReviewStatisticCollection extends WKCollection {
-  /**
-   * An array of returned review statistics.
-   */
-  data: WKReviewStatistic[];
-}
 
 /**
  * Data for a review statistic returned from the WaniKani API.
@@ -58,7 +15,7 @@ export interface WKReviewStatisticCollection extends WKCollection {
  * @category Data
  * @category Review Statistics
  */
-export interface WKReviewStatisticData {
+export interface ReviewStatisticData {
   /**
    * Timestamp when the review statistic was created.
    */
@@ -120,10 +77,77 @@ export interface WKReviewStatisticData {
   subject_id: number;
 
   /**
-   * The type of the associated subject, one of: `kanji`, `radical`, or `vocabulary`.
+   * The type of the associated subject.
    */
   subject_type: SubjectType;
 }
+export const ReviewStatisticData = v.object({
+  created_at: DatableString,
+  hidden: v.boolean(),
+  meaning_correct: v.number(),
+  meaning_current_streak: v.number(),
+  meaning_incorrect: v.number(),
+  meaning_max_streak: v.number(),
+  percentage_correct: v.number(),
+  reading_correct: v.number(),
+  reading_current_streak: v.number(),
+  reading_incorrect: v.number(),
+  reading_max_streak: v.number(),
+  subject_id: v.number(),
+  subject_type: SubjectType,
+});
+
+/**
+ * Review statistics summarize the activity recorded in reviews. They contain sum the number of correct and incorrect
+ * answers for both meaning and reading. They track current and maximum streaks of correct answers. They store the
+ * overall percentage of correct answers versus total answers.
+ *
+ * A review statistic is created when the user has done their first review on the related subject.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#review-statistics}
+ * @category Resources
+ * @category Review Statistics
+ */
+export interface ReviewStatistic extends BaseResource {
+  /**
+   * Data for the returned review statistic.
+   */
+  data: ReviewStatisticData;
+
+  /**
+   * A unique number identifying the review statistic.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "review_statistic";
+}
+export const ReviewStatistic = v.object({
+  ...BaseResource.entries,
+  data: ReviewStatisticData,
+  id: v.number(),
+  object: v.literal("review_statistic"),
+});
+
+/**
+ * A collection of review statistics returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-review-statistics}
+ * @category Collections
+ * @category Review Statistics
+ */
+export interface ReviewStatisticCollection extends BaseCollection {
+  /**
+   * An array of returned review statistics.
+   */
+  data: ReviewStatistic[];
+}
+export const ReviewStatisticCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(ReviewStatistic),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Statistic Collection.
@@ -155,17 +179,15 @@ export interface ReviewStatisticParameters extends CollectionParameters {
   subject_ids?: number[];
 
   /**
-   * Only review statistics where `data.subject_type` matches one of the array values are returned. Valid values are:
-   * `radical`, `kanji`, or `vocabulary`.
+   * Only review statistics where `data.subject_type` matches one of the array values are returned.
    */
   subject_types?: SubjectTuple;
 }
-export const ReviewStatisticParameters = extendCollectionParameters(
-  v.object({
-    hidden: v.optional(v.boolean()),
-    percentages_greater_than: v.optional(v.number()),
-    percentages_less_than: v.optional(v.number()),
-    subject_ids: v.optional(v.array(v.number())),
-    subject_types: v.optional(SubjectTuple),
-  }),
-);
+export const ReviewStatisticParameters = v.object({
+  ...CollectionParameters.entries,
+  hidden: v.optional(v.boolean()),
+  percentages_greater_than: v.optional(v.number()),
+  percentages_less_than: v.optional(v.number()),
+  subject_ids: v.optional(v.array(v.number())),
+  subject_types: v.optional(SubjectTuple),
+});

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -1,122 +1,8 @@
 import * as v from "valibot";
-import { type CollectionParameters, DatableString, type WKCollection, type WKResource } from "../base/v20170710.js";
-import type { SpacedRepetitionSystemStageNumber } from "../spaced-repetition-systems/v20170710.js";
-import type { WKAssignment } from "../assignments/v20170710.js";
-import type { WKReviewStatistic } from "../review-statistics/v20170710.js";
-import { extendCollectionParameters } from "../internal/index.js";
-
-/**
- * The base object used in the request to create a new review via the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
- * @category Reviews
- * @internal
- */
-interface ReviewObjectdBase {
-  /**
-   * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
-   */
-  incorrect_meaning_answers: number;
-
-  /**
-   * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
-   * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
-   */
-  incorrect_reading_answers: number;
-
-  /**
-   * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
-   * Must be in the past, but after `assignment.available_at`.
-   */
-  created_at?: DatableString | Date;
-}
-const ReviewObjectdBase = v.object({
-  incorrect_meaning_answers: v.number(),
-  incorrect_reading_answers: v.number(),
-  created_at: v.optional(v.union([DatableString, v.date()])),
-});
-
-/**
- * A created review returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
- * @category Resources
- * @category Reviews
- */
-export interface WKCreatedReview extends WKResource {
-  /**
-   * Data for the created review.
-   * @see {@link https://docs.api.wanikani.com/20170710/#reviews}
-   */
-  data: WKReviewData;
-
-  /**
-   * A unique number identifying the review.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "review";
-
-  /**
-   * The resources updated alongside creating the review.
-   */
-  resources_updated: {
-    /**
-     * The updated assignment upon creating the review.
-     * @see {@link https://docs.api.wanikani.com/20170710/#assignments}
-     */
-    assignment: WKAssignment;
-
-    /**
-     * The updated review statistic upon creating the review.
-     * @see {@link https://docs.api.wanikani.com/20170710/#review-statistics}
-     */
-    review_statistic: WKReviewStatistic;
-  };
-}
-
-/**
- * Reviews log all the correct and incorrect answers provided through the 'Reviews' section of WaniKani. Review records
- * are created when a user answers all the parts of a subject correctly once; some subjects have both meaning or reading
- * parts, and some only have one or the other. Note that reviews are not created for the quizzes in lessons.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#reviews}
- * @category Resources
- * @category Reviews
- */
-export interface WKReview extends WKResource {
-  /**
-   * Data for the returned review.
-   */
-  data: WKReviewData;
-
-  /**
-   * A unique number identifying the review.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "review";
-}
-
-/**
- * A collection of reviews returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-reviews}
- * @category Collections
- * @category Reviews
- */
-export interface WKReviewCollection extends WKCollection {
-  /**
-   * An array of returned reviews.
-   */
-  data: WKReview[];
-}
+import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
+import type { Assignment } from "../assignments/v20170710.js";
+import type { ReviewStatistic } from "../review-statistics/v20170710.js";
+import { SpacedRepetitionSystemStageNumber } from "../spaced-repetition-systems/v20170710.js";
 
 /**
  * Review data shared between created and read reviews.
@@ -125,7 +11,7 @@ export interface WKReviewCollection extends WKCollection {
  * @category Data
  * @category Reviews
  */
-export interface WKReviewData {
+export interface ReviewData {
   /**
    * Unique identifier of the associated assignment.
    */
@@ -167,6 +53,66 @@ export interface WKReviewData {
    */
   subject_id: number;
 }
+export const ReviewData = v.object({
+  assignment_id: v.number(),
+  created_at: DatableString,
+  ending_srs_stage: SpacedRepetitionSystemStageNumber,
+  incorrect_meaning_answers: v.number(),
+  incorrect_reading_answers: v.number(),
+  spaced_repetition_system_id: v.number(),
+  starting_srs_stage: SpacedRepetitionSystemStageNumber,
+  subject_id: v.number(),
+});
+
+/**
+ * Reviews log all the correct and incorrect answers provided through the 'Reviews' section of WaniKani. Review records
+ * are created when a user answers all the parts of a subject correctly once; some subjects have both meaning or reading
+ * parts, and some only have one or the other. Note that reviews are not created for the quizzes in lessons.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#reviews}
+ * @category Resources
+ * @category Reviews
+ */
+export interface Review extends BaseResource {
+  /**
+   * Data for the returned review.
+   */
+  data: ReviewData;
+
+  /**
+   * A unique number identifying the review.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "review";
+}
+export const Review = v.object({
+  ...BaseResource.entries,
+  data: ReviewData,
+  id: v.number(),
+  object: v.literal("review"),
+});
+
+/**
+ * A collection of reviews returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-reviews}
+ * @category Collections
+ * @category Reviews
+ */
+export interface ReviewCollection extends BaseCollection {
+  /**
+   * An array of returned reviews.
+   */
+  data: Review[];
+}
+export const ReviewCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Review),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Collection.
@@ -187,12 +133,42 @@ export interface ReviewParameters extends CollectionParameters {
    */
   subject_ids?: number[];
 }
-export const ReviewParameters = extendCollectionParameters(
-  v.object({
-    assignment_ids: v.optional(v.array(v.number())),
-    subject_ids: v.optional(v.array(v.number())),
-  }),
-);
+export const ReviewParameters = v.object({
+  ...CollectionParameters.entries,
+  assignment_ids: v.optional(v.array(v.number())),
+  subject_ids: v.optional(v.array(v.number())),
+});
+
+/**
+ * The base object used in the request to create a new review via the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
+ * @category Reviews
+ * @internal
+ */
+interface ReviewObjectdBase {
+  /**
+   * Must be zero or a positive number. This is the number of times the meaning was answered incorrectly.
+   */
+  incorrect_meaning_answers: number;
+
+  /**
+   * Must be zero or a positive number. This is the number of times the reading was answered incorrectly. Note that
+   * subjects with a type of `radical` do not quiz on readings. Thus, set this value to `0`.
+   */
+  incorrect_reading_answers: number;
+
+  /**
+   * Timestamp when the review was completed. Defaults to the time of the request if omitted from the request body.
+   * Must be in the past, but after `assignment.available_at`.
+   */
+  created_at?: DatableString | Date;
+}
+const ReviewObjectdBase = v.object({
+  incorrect_meaning_answers: v.number(),
+  incorrect_reading_answers: v.number(),
+  created_at: v.optional(v.union([DatableString, v.date()])),
+});
 
 /**
  * The review object used in the request to create a new review via the WaniKani API by Assignment ID.
@@ -211,13 +187,11 @@ export interface ReviewObjectWithAssignmentId extends ReviewObjectdBase {
    */
   subject_id?: never;
 }
-export const ReviewObjectWithAssignmentId = v.intersect([
-  ReviewObjectdBase,
-  v.object({
-    assignment_id: v.number(),
-    subject_id: v.optional(v.never()),
-  }),
-]);
+export const ReviewObjectWithAssignmentId = v.object({
+  ...ReviewObjectdBase.entries,
+  assignment_id: v.number(),
+  subject_id: v.optional(v.never()),
+});
 
 /**
  * The review object used in the request to create a new review via the WaniKani API by Subject ID.
@@ -236,13 +210,11 @@ export interface ReviewObjectWithSubjectId extends ReviewObjectdBase {
    */
   assignment_id?: never;
 }
-export const ReviewObjectWithSubjectId = v.intersect([
-  ReviewObjectdBase,
-  v.object({
-    subject_id: v.number(),
-    assignment_id: v.optional(v.never()),
-  }),
-]);
+export const ReviewObjectWithSubjectId = v.object({
+  ...ReviewObjectdBase.entries,
+  subject_id: v.number(),
+  assignment_id: v.optional(v.never()),
+});
 
 /**
  * The payload used in the request to create a new review via the WaniKani API.
@@ -260,3 +232,29 @@ export interface ReviewPayload {
 export const ReviewPayload = v.object({
   review: v.union([ReviewObjectWithAssignmentId, ReviewObjectWithSubjectId]),
 });
+
+/**
+ * A created review returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#create-a-review}
+ * @category Resources
+ * @category Reviews
+ */
+export interface CreatedReview extends Review {
+  /**
+   * The resources updated alongside creating the review.
+   */
+  resources_updated: {
+    /**
+     * The updated assignment upon creating the review.
+     * @see {@link https://docs.api.wanikani.com/20170710/#assignments}
+     */
+    assignment: Assignment;
+
+    /**
+     * The updated review statistic upon creating the review.
+     * @see {@link https://docs.api.wanikani.com/20170710/#review-statistics}
+     */
+    review_statistic: ReviewStatistic;
+  };
+}

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -1,5 +1,26 @@
 import * as v from "valibot";
-import { CollectionParameters, type DatableString, type WKCollection, type WKResource } from "../base/v20170710.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
+
+/**
+ * The minimum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
+ *
+ * @category Spaced Repetition Systems
+ */
+export const MIN_SRS_STAGE = 0;
+
+/**
+ * The maximum SRS Stage Number used in WaniKani's reviews; exported for use in lieu of a Magic Number.
+ *
+ * @category Spaced Repetition Systems
+ */
+export const MAX_SRS_REVIEW_STAGE = 8;
+
+/**
+ * The maximum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
+ *
+ * @category Spaced Repetition Systems
+ */
+export const MAX_SRS_STAGE = 9;
 
 /**
  * A valid WaniKani Spaced Repetition System (SRS) Stage Number, based on the known SRS' on WaniKani and its API.
@@ -7,73 +28,39 @@ import { CollectionParameters, type DatableString, type WKCollection, type WKRes
  * @category Spaced Repetition Systems
  */
 export type SpacedRepetitionSystemStageNumber = number & {};
-const MinSrsStage = 0;
-const MaxSrsReviewStage = 8;
-const MaxSrsStage = 9;
-export const SpacedRepetitionSystemStageNumber = v.pipe(v.number(), v.minValue(MinSrsStage), v.maxValue(MaxSrsStage));
-
-/**
- * The minimum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
- *
- * @category Spaced Repetition Systems
- */
-export const MIN_SRS_STAGE: SpacedRepetitionSystemStageNumber = v.parse(SpacedRepetitionSystemStageNumber, MinSrsStage);
-
-/**
- * The maximum SRS Stage Number used in WaniKani's reviews; exported for use in lieu of a Magic Number.
- *
- * @category Spaced Repetition Systems
- */
-export const MAX_SRS_REVIEW_STAGE: SpacedRepetitionSystemStageNumber = v.parse(
-  SpacedRepetitionSystemStageNumber,
-  MaxSrsReviewStage,
+export const SpacedRepetitionSystemStageNumber = v.pipe(
+  v.number(),
+  v.minValue(MIN_SRS_STAGE),
+  v.maxValue(MAX_SRS_STAGE),
 );
 
 /**
- * The maximum SRS Stage Number used in WaniKani's SRS; exported for use in lieu of a Magic Number.
- *
- * @category Spaced Repetition Systems
- */
-export const MAX_SRS_STAGE: SpacedRepetitionSystemStageNumber = v.parse(SpacedRepetitionSystemStageNumber, MaxSrsStage);
-
-/**
- * Available spaced repetition systems used for calculating `srs_stage` changes to Assignments and Reviews. Has
- * relationship with Subjects.
+ * An individual Spaced Repetition System (SRS) Stage.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#spaced-repetition-systems}
- * @category Resources
  * @category Spaced Repetition Systems
  */
-export interface WKSpacedRepetitionSystem extends WKResource {
+export interface SpacedRepetitionSystemStage {
   /**
-   * Data for the return Spaced Repetition System.
+   * The length of time added to the time of review registration, adjusted to the beginning of the hour.
    */
-  data: WKSpacedRepetitionSystemData;
+  interval: number | null;
 
   /**
-   * A unique number identifying the Spaced Repetition System.
+   * Unit of time. Can be the following: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, and `weeks`.
    */
-  id: number;
+  interval_unit: "days" | "hours" | "milliseconds" | "minutes" | "seconds" | "weeks" | null;
 
   /**
-   * The kind of object returned.
+   * The position of the stage within the continuous order.
    */
-  object: "spaced_repetition_system";
+  position: SpacedRepetitionSystemStageNumber;
 }
-
-/**
- * A collection of Spaced Repetition Systems returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-spaced-repetition-systems}
- * @category Collections
- * @category Spaced Repetition Systems
- */
-export interface WKSpacedRepetitionSystemCollection extends WKCollection {
-  /**
-   * An array of returned Spaced Repetition Systems.
-   */
-  data: WKSpacedRepetitionSystem[];
-}
+export const SpacedRepetitionSystemStage = v.object({
+  interval: v.union([v.number(), v.null()]),
+  interval_unit: v.union([v.picklist(["days", "hours", "milliseconds", "minutes", "seconds", "weeks"]), v.null()]),
+  position: SpacedRepetitionSystemStageNumber,
+});
 
 /**
  * Data for a Spaced Repetition System returned from the WaniKani API.
@@ -82,7 +69,7 @@ export interface WKSpacedRepetitionSystemCollection extends WKCollection {
  * @category Data
  * @category Spaced Repetition Systems
  */
-export interface WKSpacedRepetitionSystemData {
+export interface SpacedRepetitionSystemData {
   /**
    * `position` of the burning stage.
    */
@@ -111,7 +98,7 @@ export interface WKSpacedRepetitionSystemData {
   /**
    * A collection of stages.
    */
-  stages: WKSpacedRepetitionSystemStage[];
+  stages: SpacedRepetitionSystemStage[];
 
   /**
    * `position` of the starting stage.
@@ -123,6 +110,65 @@ export interface WKSpacedRepetitionSystemData {
    */
   unlocking_stage_position: SpacedRepetitionSystemStageNumber;
 }
+export const SpacedRepetitionSystemData = v.object({
+  burning_stage_position: SpacedRepetitionSystemStageNumber,
+  created_at: DatableString,
+  description: v.string(),
+  name: v.string(),
+  passing_stage_position: SpacedRepetitionSystemStageNumber,
+  stages: v.array(SpacedRepetitionSystemStage),
+  starting_stage_position: SpacedRepetitionSystemStageNumber,
+  unlocking_stage_position: SpacedRepetitionSystemStageNumber,
+});
+
+/**
+ * Available spaced repetition systems used for calculating `srs_stage` changes to Assignments and Reviews. Has
+ * relationship with Subjects.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#spaced-repetition-systems}
+ * @category Resources
+ * @category Spaced Repetition Systems
+ */
+export interface SpacedRepetitionSystem extends BaseResource {
+  /**
+   * Data for the return Spaced Repetition System.
+   */
+  data: SpacedRepetitionSystemData;
+
+  /**
+   * A unique number identifying the Spaced Repetition System.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "spaced_repetition_system";
+}
+export const SpacedRepetitionSystem = v.object({
+  ...BaseResource.entries,
+  data: SpacedRepetitionSystemData,
+  id: v.number(),
+  object: v.literal("spaced_repetition_system"),
+});
+
+/**
+ * A collection of Spaced Repetition Systems returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-spaced-repetition-systems}
+ * @category Collections
+ * @category Spaced Repetition Systems
+ */
+export interface SpacedRepetitionSystemCollection extends BaseCollection {
+  /**
+   * An array of returned Spaced Repetition Systems.
+   */
+  data: SpacedRepetitionSystem[];
+}
+export const SpacedRepetitionSystemCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(SpacedRepetitionSystem),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Spaced Repetition System Collection.
@@ -134,26 +180,3 @@ export interface WKSpacedRepetitionSystemData {
  */
 export type SpacedRepetitionSystemParameters = CollectionParameters;
 export const SpacedRepetitionSystemParameters = CollectionParameters;
-
-/**
- * An individual Spaced Repetition System (SRS) Stage.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#spaced-repetition-systems}
- * @category Spaced Repetition Systems
- */
-export interface WKSpacedRepetitionSystemStage {
-  /**
-   * The length of time added to the time of review registration, adjusted to the beginning of the hour.
-   */
-  interval: number | null;
-
-  /**
-   * Unit of time. Can be the following: `milliseconds`, `seconds`, `minutes`, `hours`, `days`, and `weeks`.
-   */
-  interval_unit: "days" | "hours" | "milliseconds" | "minutes" | "seconds" | "weeks" | null;
-
-  /**
-   * The position of the stage within the continuous order.
-   */
-  position: SpacedRepetitionSystemStageNumber;
-}

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -1,13 +1,12 @@
 import * as v from "valibot";
 import {
-  type CollectionParameters,
-  type DatableString,
+  BaseCollection,
+  BaseResource,
+  CollectionParameters,
+  DatableString,
   SubjectTuple,
-  type SubjectType,
-  type WKCollection,
-  type WKResource,
+  SubjectType,
 } from "../base/v20170710.js";
-import { extendCollectionParameters } from "../internal/index.js";
 
 /**
  * Data found in all study materials whether they are being created/updated, or received from the WaniKani API.
@@ -15,13 +14,13 @@ import { extendCollectionParameters } from "../internal/index.js";
  * @category Data
  * @category Study Materials
  * @remarks For creating study materials, use {@link StudyMaterialCreatePayload}; for updating study materials, use
- * {@link StudyMaterialUpdatePayload}; for study materials received from the API, use {@link WKStudyMaterialData}.
+ * {@link StudyMaterialUpdatePayload}; for study materials received from the API, use {@link StudyMaterialData}.
  */
 export interface StudyMaterialBaseData {
   /**
    * Free form note related to the meaning(s) of the associated subject.
    */
-  meaning_note: string | null;
+  meaning_note: string;
 
   /**
    * Synonyms for the meaning of the subject. These are used as additional correct answers during reviews.
@@ -31,12 +30,12 @@ export interface StudyMaterialBaseData {
   /**
    * Free form note related to the reading(s) of the associated subject.
    */
-  reading_note: string | null;
+  reading_note: string;
 }
 export const StudyMaterialBaseData = v.object({
-  meaning_note: v.union([v.string(), v.null()]),
+  meaning_note: v.string(),
   meaning_synonyms: v.array(v.string()),
-  reading_note: v.union([v.string(), v.null()]),
+  reading_note: v.string(),
 });
 
 /**
@@ -46,7 +45,7 @@ export const StudyMaterialBaseData = v.object({
  * @category Data
  * @category Study Materials
  */
-export interface WKStudyMaterialData extends StudyMaterialBaseData {
+export interface StudyMaterialData extends StudyMaterialBaseData {
   /**
    * Timestamp when the study material was created.
    */
@@ -63,10 +62,17 @@ export interface WKStudyMaterialData extends StudyMaterialBaseData {
   subject_id: number;
 
   /**
-   * The type of the associated subject, one of: `kanji`, `radical`, or `vocabulary`.
+   * The type of the associated subject.
    */
   subject_type: SubjectType;
 }
+export const StudyMaterialData = v.object({
+  ...StudyMaterialBaseData.entries,
+  created_at: DatableString,
+  hidden: v.boolean(),
+  subject_id: v.number(),
+  subject_type: SubjectType,
+});
 
 /**
  * Study materials store user-specific notes and synonyms for a given subject. The records are created as soon as the
@@ -76,11 +82,11 @@ export interface WKStudyMaterialData extends StudyMaterialBaseData {
  * @category Resources
  * @category Study Materials
  */
-export interface WKStudyMaterial extends WKResource {
+export interface StudyMaterial extends BaseResource {
   /**
    * Data for the returned study material.
    */
-  data: WKStudyMaterialData;
+  data: StudyMaterialData;
 
   /**
    * A unique number identifying the study material.
@@ -92,6 +98,12 @@ export interface WKStudyMaterial extends WKResource {
    */
   object: "study_material";
 }
+export const StudyMaterial = v.object({
+  ...BaseResource.entries,
+  data: StudyMaterialData,
+  id: v.number(),
+  object: v.literal("study_material"),
+});
 
 /**
  * A collection of study materials returned from the WaniKani API.
@@ -100,12 +112,16 @@ export interface WKStudyMaterial extends WKResource {
  * @category Collections
  * @category Study Materials
  */
-export interface WKStudyMaterialCollection extends WKCollection {
+export interface StudyMaterialCollection extends BaseCollection {
   /**
    * An array of returned study materials.
    */
-  data: WKStudyMaterial[];
+  data: StudyMaterial[];
 }
+export const StudyMaterialCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(StudyMaterial),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Study Material Collection.
@@ -127,18 +143,16 @@ export interface StudyMaterialParameters extends CollectionParameters {
   subject_ids?: number[];
 
   /**
-   * Only study material records where `data.subject_type` matches one of the array values are returned. Valid values
-   * are: `radical`, `kanji`, or `vocabulary`.
+   * Only study material records where `data.subject_type` matches one of the array values are returned.
    */
   subject_types?: SubjectTuple;
 }
-export const StudyMaterialParameters = extendCollectionParameters(
-  v.object({
-    hidden: v.optional(v.boolean()),
-    subject_ids: v.optional(v.array(v.number())),
-    subject_types: v.optional(SubjectTuple),
-  }),
-);
+export const StudyMaterialParameters = v.object({
+  ...CollectionParameters.entries,
+  hidden: v.optional(v.boolean()),
+  subject_ids: v.optional(v.array(v.number())),
+  subject_types: v.optional(SubjectTuple),
+});
 
 /**
  * The payload sent to the WaniKani API when updating study materials.
@@ -163,9 +177,7 @@ export interface StudyMaterialCreatePayload extends StudyMaterialUpdatePayload {
    */
   subject_id: number;
 }
-export const StudyMaterialCreatePayload = v.intersect([
-  StudyMaterialUpdatePayload,
-  v.object({
-    subject_id: v.number(),
-  }),
-]);
+export const StudyMaterialCreatePayload = v.object({
+  ...StudyMaterialUpdatePayload.entries,
+  subject_id: v.number(),
+});

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -153,6 +153,29 @@ export type RadicalCharacterImage = {
       /**
        * The content type of the image.
        */
+      content_type: "image/png";
+      /**
+       * Details about the image. Each `content_type` returns a uniquely structured object.
+       */
+      metadata: {
+        /**
+         * Color of the asset in hexadecimal
+         */
+        color: string;
+        /**
+         * Dimension of the asset in pixels
+         */
+        dimensions: string;
+        /**
+         * A name descriptor
+         */
+        style_name: string;
+      };
+    }
+  | {
+      /**
+       * The content type of the image.
+       */
       content_type: "image/svg+xml";
 
       /**
@@ -163,14 +186,6 @@ export type RadicalCharacterImage = {
          * The SVG asset contains built-in CSS styling.
          */
         inline_styles: boolean;
-      };
-    }
-  | {
-      content_type: "image/png";
-      metadata: {
-        color: string;
-        dimensions: string;
-        style_name: string;
       };
     }
 );

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -1,465 +1,12 @@
 import * as v from "valibot";
 import {
-  type CollectionParameters,
-  type DatableString,
+  BaseCollection,
+  BaseResource,
+  CollectionParameters,
+  DatableString,
   Level,
   SubjectTuple,
-  type WKCollection,
-  type WKResource,
 } from "../base/v20170710.js";
-import { extendCollectionParameters } from "../internal/index.js";
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a kana-only vocabulary subject, and provides better type assertions requiring
- * less type checking in code.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface WKKanaVocabulary extends WKResource {
-  /**
-   * Data for the returned vocabulary.
-   */
-  data: WKKanaVocabularyData;
-
-  /**
-   * A unique number identifying the vocabulary.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "kana_vocabulary";
-}
-
-/**
- * A collection of kana-only vocabulary subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface WKKanaVocabularyCollection extends WKCollection {
-  /**
-   * An array of returned vocabulary subjects.
-   */
-  data: WKKanaVocabulary[];
-}
-
-/**
- * Data returned only for kana-only vocabulary subjects.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Data
- * @category Subjects
- */
-export interface WKKanaVocabularyData extends WKSubjectData {
-  /**
-   * The UTF-8 characters for the subject, including kanji and hiragana.
-   */
-  characters: string;
-
-  /**
-   * A collection of context sentences.
-   */
-  context_sentences: WKVocabularyContextSentence[];
-
-  /**
-   * Parts of speech.
-   */
-  parts_of_speech: string[];
-
-  /**
-   * A collection of pronunciation audio.
-   */
-  pronunciation_audios: WKVocabularyPronunciationAudio[];
-
-  /**
-   * Kana-only Vocabulary subjects will never have an `amalgamation_subject_ids` property defined.
-   */
-  amalgamation_subject_ids?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `character_images` property defined.
-   */
-  character_images?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `component_subject_ids` property defined.
-   */
-  component_subject_ids?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `meaning_hint` property defined.
-   */
-  meaning_hint?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `reading_hint` property defined.
-   */
-  reading_hint?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `reading_mnemonic` property defined.
-   */
-  reading_mnemonic?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `readings` property defined.
-   */
-  readings?: never;
-
-  /**
-   * Kana-only Vocabulary subjects will never have a `visually_similar_subject_ids` property defined.
-   */
-  visually_similar_subject_ids?: never;
-}
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a kanji, and provides better type assertions requiring less type checking in
- * code.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface WKKanji extends WKResource {
-  /**
-   * Data for the returned kanji.
-   */
-  data: WKKanjiData;
-
-  /**
-   * A unique number identifying the kanji.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "kanji";
-}
-
-/**
- * A collection of kanji subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface WKKanjiCollection extends WKCollection {
-  /**
-   * An array of returned kanji subjects.
-   */
-  data: WKKanji[];
-}
-
-/**
- * Data returned only for kanji subjects.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Data
- * @category Subjects
- */
-export interface WKKanjiData extends WKSubjectData {
-  /**
-   * An array of numeric identifiers for the vocabulary that have the kanji as a component.
-   */
-  amalgamation_subject_ids: number[];
-
-  /**
-   * The UTF-8 characters for the subject, including kanji and hiragana.
-   */
-  characters: string;
-
-  /**
-   * An array of numeric identifiers for the radicals that make up this kanji. Note that these are the subjects that
-   * must have passed assignments in order to unlock this subject's assignment.
-   */
-  component_subject_ids: number[];
-
-  /**
-   * Meaning hint for the kanji.
-   */
-  meaning_hint: string | null;
-
-  /**
-   * Reading hint for the kanji.
-   */
-  reading_hint: string | null;
-
-  /**
-   * The kanji's reading mnemonic.
-   */
-  reading_mnemonic: string;
-
-  /**
-   * Selected readings for the kanji.
-   */
-  readings: WKKanjiReading[];
-
-  /**
-   * An array of numeric identifiers for kanji which are visually similar to the kanji in question.
-   */
-  visually_similar_subject_ids: number[];
-
-  /**
-   * Kanji subjects will never have a `character_images` property defined.
-   */
-  character_images?: never;
-
-  /**
-   * Kanji subjects will never have a `context_sentences` property defined.
-   */
-  context_sentences?: never;
-
-  /**
-   * Kanji subjects will never have a `parts_of_speech` property defined.
-   */
-  parts_of_speech?: never;
-
-  /**
-   * Kanji subjects will never have a `pronunciation_audios` property defined.
-   */
-  pronunciation_audios?: never;
-}
-
-/**
- * Information pertaining to a reading of a kanji subject.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Subjects
- */
-export interface WKKanjiReading {
-  /**
-   * Indicates if the reading is used to evaluate user input for correctness.
-   */
-  accepted_answer: boolean;
-
-  /**
-   * Indicates priority in the WaniKani system.
-   */
-  primary: boolean;
-
-  /**
-   * A singular subject reading.
-   */
-  reading: string;
-
-  /**
-   * The kanji reading's classfication: `kunyomi`, `nanori`, or `onyomi`.
-   */
-  type: "kunyomi" | "nanori" | "onyomi";
-}
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a radical, and provides better type assertions requiring less type checking in
- * code.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface WKRadical extends WKResource {
-  /**
-   * Data for the returned radical.
-   */
-  data: WKRadicalData;
-
-  /**
-   * A unique number identifying the radical.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "radical";
-}
-
-/**
- * An image representing a radical subject.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Subjects
- */
-export interface WKRadicalCharacterImage {
-  /**
-   * The content type of the image. Currently the API delivers `image/png` and `image/svg+xml`.
-   */
-  content_type: "image/png" | "image/svg+xml";
-
-  /**
-   * Details about the image. Each `content_type` returns a uniquely structured object.
-   */
-  metadata: WKRadicalCharacterImagePngMetadata | WKRadicalCharacterImageSvgMetadata;
-
-  /**
-   * The location of the image.
-   */
-  url: string;
-}
-
-/**
- * Character image metadata for `image/png` type images.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Subjects
- */
-export interface WKRadicalCharacterImagePngMetadata {
-  /**
-   * Color of the asset in hexadecimal.
-   */
-  color: string;
-
-  /**
-   * Dimension of the asset in pixels.
-   */
-  dimensions: string;
-
-  /**
-   * A name descriptor.
-   */
-  style_name: string;
-
-  /**
-   * A character image of type `image/png` will never have its `inline_styles` property defined.
-   */
-  inline_styles?: never;
-}
-
-/**
- * Character image metadata for `image/svg+xml` type images.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Subjects
- */
-export interface WKRadicalCharacterImageSvgMetadata {
-  /**
-   * The SVG asset contains built-in CSS styling.
-   */
-  inline_styles: boolean;
-
-  /**
-   * A character image of type `image/svg+xml` will never have its `color` property defined.
-   */
-  color?: never;
-
-  /**
-   * A character image of type `image/svg+xml` will never have its `dimensions` property defined.
-   */
-  dimensions?: never;
-
-  /**
-   * A character image of type `image/svg+xml` will never have its `style_name` property defined.
-   */
-  style_name?: never;
-}
-
-/**
- * A collection of kanji subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface WKRadicalCollection extends WKCollection {
-  /**
-   * An array of returned radical subjects.
-   */
-  data: WKRadical[];
-}
-
-/**
- * Data returned only for radical subjects.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Data
- * @category Subjects
- */
-export interface WKRadicalData extends WKSubjectData {
-  /**
-   * An array of numeric identifiers for the kanji that have the radical as a component.
-   */
-  amalgamation_subject_ids: number[];
-
-  /**
-   * A collection of images of the radical.
-   */
-  character_images: WKRadicalCharacterImage[];
-
-  /**
-   * Radical subjects will never have a `component_subject_ids` property defined.
-   */
-  component_subject_ids?: never;
-
-  /**
-   * Radical subjects will never have a `context_sentences` property defined.
-   */
-  context_sentences?: never;
-
-  /**
-   * Radical subjects will never have a `meaning_hint` property defined.
-   */
-  meaning_hint?: never;
-
-  /**
-   * Radical subjects will never have a `parts_of_speech` property defined.
-   */
-  parts_of_speech?: never;
-
-  /**
-   * Radical subjects will never have a `pronunciation_audios` property defined.
-   */
-  pronunciation_audios?: never;
-
-  /**
-   * Radical subjects will never have a `reading_hint` property defined.
-   */
-  reading_hint?: never;
-
-  /**
-   * Radical subjects will never have a `reading_mnemonic` property defined.
-   */
-  reading_mnemonic?: never;
-
-  /**
-   * Radical subjects will never have a `readings` property defined.
-   */
-  readings?: never;
-
-  /**
-   * Radical subjects will never have a `visually_similar_subject_ids` property defined.
-   */
-  visually_similar_subject_ids?: never;
-}
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type is for mixed or unknown subject types, and some items will require type checking in code.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export type WKSubject = WKKanaVocabulary | WKKanji | WKRadical | WKVocabulary;
 
 /**
  * A subject's auxilliary meanings.
@@ -467,7 +14,7 @@ export type WKSubject = WKKanaVocabulary | WKKanji | WKRadical | WKVocabulary;
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface WKSubjectAuxiliaryMeaning {
+export interface SubjectAuxiliaryMeaning {
   /**
    * A singular subject meaning.
    */
@@ -479,20 +26,38 @@ export interface WKSubjectAuxiliaryMeaning {
    */
   type: "blacklist" | "whitelist";
 }
+export const SubjectAuxiliaryMeaning = v.object({
+  meaning: v.string(),
+  type: v.picklist(["blacklist", "whitelist"]),
+});
 
 /**
- * A collection of subjects of mixed or unknown types returned from the WaniKani API.
+ * Information pertaining to a subject's meaning.
  *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface WKSubjectCollection extends WKCollection {
+export interface SubjectMeaning {
   /**
-   * An array of returned subjects of mixed or unknown type.
+   * Indicates if the meaning is used to evaluate user input for correctness.
    */
-  data: WKSubject[];
+  accepted_answer: boolean;
+
+  /**
+   * A singular subject meaning.
+   */
+  meaning: string;
+
+  /**
+   * Indicates priority in the WaniKani system.
+   */
+  primary: boolean;
 }
+export const SubjectMeaning = v.object({
+  accepted_answer: v.boolean(),
+  meaning: v.string(),
+  primary: v.boolean(),
+});
 
 /**
  * The common properties of all subjects on WaniKani.
@@ -505,19 +70,11 @@ export interface WKSubjectCollection extends WKCollection {
  * @category Data
  * @category Subjects
  */
-export interface WKSubjectData {
+export interface SubjectBaseData {
   /**
    * Collection of auxiliary meanings.
    */
-  auxiliary_meanings: WKSubjectAuxiliaryMeaning[];
-
-  /**
-   * The UTF-8 characters for the subject, including kanji and hiragana.
-   *
-   * Unlike kanji and vocabulary, radicals can have a null value for `characters`. Not all radicals have a UTF entry,
-   * so the radical must be visually represented with an image instead.
-   */
-  characters: string | null;
+  auxiliary_meanings: SubjectAuxiliaryMeaning[];
 
   /**
    * Timestamp when the subject was created.
@@ -554,7 +111,7 @@ export interface WKSubjectData {
   /**
    * The subject meanings.
    */
-  meanings: WKSubjectMeaning[];
+  meanings: SubjectMeaning[];
 
   /**
    * The string that is used when generating the document URL for the subject. Radicals use their meaning, downcased.
@@ -567,111 +124,283 @@ export interface WKSubjectData {
    */
   spaced_repetition_system_id: number;
 }
+export const SubjectBaseData = v.object({
+  auxiliary_meanings: v.array(SubjectAuxiliaryMeaning),
+  created_at: DatableString,
+  document_url: v.string(),
+  hidden_at: v.union([DatableString, v.null()]),
+  lesson_position: v.number(),
+  level: Level,
+  meaning_mnemonic: v.string(),
+  meanings: v.array(SubjectMeaning),
+  slug: v.string(),
+  spaced_repetition_system_id: v.number(),
+});
 
 /**
- * A set of regular expression literals that match to various markup patterns in a Subject's Meaning/Reading Mnemonics
- * and Hints.
+ * An image representing a radical subject.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export const WK_SUBJECT_MARKUP_MATCHERS = {
+export interface RadicalCharacterImage {
   /**
-   * A regular expression literal that matches to Japanese text surrounded by `<ja>` tags.
+   * The content type of the image.
    */
-  ja: /<ja>(?<innerText>.+?)<\/ja>/gu,
+  content_type: "image/svg+xml";
 
   /**
-   * A regular expression literal that matches to Japanese kanji surrounded by `<kanji>` tags.
+   * Details about the image. Each `content_type` returns a uniquely structured object.
    */
-  kanji: /<kanji>(?<innerText>.+?)<\/kanji>/gu,
+  metadata: {
+    /**
+     * The SVG asset contains built-in CSS styling.
+     */
+    inline_styles: boolean;
+  };
 
   /**
-   * A regular expression literal that matches to a subject meaning surrounded by `<meaning>` tags.
+   * The location of the image.
    */
-  meaning: /<meaning>(?<innerText>.+?)<\/meaning>/gu,
-
-  /**
-   * A regular expression literal that matches to WaniKani Radical names surrounded by `<radical>` tags.
-   */
-  radical: /<radical>(?<innerText>.+?)<\/radical>/gu,
-
-  /**
-   * A regular expression literal that matches to a kanji/vocabulary reading surrounded by `<reading>` tags.
-   */
-  reading: /<reading>(?<innerText>.+?)<\/reading>/gu,
-
-  /**
-   * A regular expression literal that matches to WaniKani Vocabulary surrounded by `<vocabulary>` tags.
-   */
-  vocabulary: /<vocabulary>(?<innerText>.+?)<\/vocabulary>/gu,
-} as const;
-
-/**
- * Information pertaining to a subject's meaning.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Subjects
- */
-export interface WKSubjectMeaning {
-  /**
-   * Indicates if the meaning is used to evaluate user input for correctness.
-   */
-  accepted_answer: boolean;
-
-  /**
-   * A singular subject meaning.
-   */
-  meaning: string;
-
-  /**
-   * Indicates priority in the WaniKani system.
-   */
-  primary: boolean;
+  url: string;
 }
+export const RadicalCharacterImage = v.object({
+  content_type: v.literal("image/svg+xml"),
+  metadata: v.object({
+    inline_styles: v.boolean(),
+  }),
+  url: v.string(),
+});
+
+/**
+ * Data returned only for radical subjects.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Data
+ * @category Subjects
+ */
+export interface RadicalData extends SubjectBaseData {
+  /**
+   * An array of numeric identifiers for the kanji that have the radical as a component.
+   */
+  amalgamation_subject_ids: number[];
+
+  /**
+   * A collection of images of the radical.
+   */
+  character_images: RadicalCharacterImage[];
+
+  /**
+   * Unlike kanji and vocabulary, radicals can have a null value for characters. Not all radicals have a UTF entry, so
+   * the radical must be visually represented with an image instead.
+   */
+  characters: string | null;
+}
+export const RadicalData = v.object({
+  ...SubjectBaseData.entries,
+  amalgamation_subject_ids: v.array(v.number()),
+  character_images: v.array(RadicalCharacterImage),
+  characters: v.union([v.string(), v.null()]),
+});
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
  * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
  * differently than the common attribute of the same name.
  *
- * This type asserts the subject type is a vocabulary subject, and provides better type assertions requiring less type
- * checking in code.
+ * This type asserts the subject type is a radical.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Resources
  * @category Subjects
  */
-export interface WKVocabulary extends WKResource {
+export interface Radical extends BaseResource {
   /**
-   * Data for the returned vocabulary.
+   * Data for the returned radical.
    */
-  data: WKVocabularyData;
+  data: RadicalData;
 
   /**
-   * A unique number identifying the vocabulary.
+   * A unique number identifying the radical.
    */
   id: number;
 
   /**
    * The kind of object returned.
    */
-  object: "vocabulary";
+  object: "radical";
 }
+export const Radical = v.object({
+  ...BaseResource.entries,
+  data: RadicalData,
+  id: v.number(),
+  object: v.literal("radical"),
+});
 
 /**
- * A collection of vocabulary subjects returned from the WaniKani API.
+ * A collection of radical subjects returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
  * @category Collections
  * @category Subjects
  */
-export interface WKVocabularyCollection extends WKCollection {
+export interface RadicalCollection extends BaseCollection {
   /**
-   * An array of returned vocabulary subjects.
+   * An array of returned radical subjects.
    */
-  data: WKVocabulary[];
+  data: Radical[];
 }
+export const RadicalCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Radical),
+});
+
+/**
+ * Information pertaining to a reading of a kanji subject.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Subjects
+ */
+export interface KanjiReading {
+  /**
+   * Indicates if the reading is used to evaluate user input for correctness.
+   */
+  accepted_answer: boolean;
+
+  /**
+   * Indicates priority in the WaniKani system.
+   */
+  primary: boolean;
+
+  /**
+   * A singular subject reading.
+   */
+  reading: string;
+
+  /**
+   * The kanji reading's classfication: `kunyomi`, `nanori`, or `onyomi`.
+   */
+  type: "kunyomi" | "nanori" | "onyomi";
+}
+export const KanjiReading = v.object({
+  accepted_answer: v.boolean(),
+  primary: v.boolean(),
+  reading: v.string(),
+  type: v.picklist(["kunyomi", "nanori", "onyomi"]),
+});
+
+/**
+ * Data returned only for kanji subjects.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Data
+ * @category Subjects
+ */
+export interface KanjiData extends SubjectBaseData {
+  /**
+   * An array of numeric identifiers for the vocabulary that have the kanji as a component.
+   */
+  amalgamation_subject_ids: number[];
+
+  /**
+   * The UTF-8 characters for the subject, including kanji and hiragana.
+   */
+  characters: string;
+
+  /**
+   * An array of numeric identifiers for the radicals that make up this kanji. Note that these are the subjects that
+   * must have passed assignments in order to unlock this subject's assignment.
+   */
+  component_subject_ids: number[];
+
+  /**
+   * Meaning hint for the kanji.
+   */
+  meaning_hint: string | null;
+
+  /**
+   * Reading hint for the kanji.
+   */
+  reading_hint: string | null;
+
+  /**
+   * The kanji's reading mnemonic.
+   */
+  reading_mnemonic: string;
+
+  /**
+   * Selected readings for the kanji.
+   */
+  readings: KanjiReading[];
+
+  /**
+   * An array of numeric identifiers for kanji which are visually similar to the kanji in question.
+   */
+  visually_similar_subject_ids: number[];
+}
+export const KanjiData = v.object({
+  ...SubjectBaseData.entries,
+  amalgamation_subject_ids: v.array(v.number()),
+  characters: v.string(),
+  component_subject_ids: v.array(v.number()),
+  meaning_hint: v.union([v.string(), v.null()]),
+  reading_hint: v.union([v.string(), v.null()]),
+  reading_mnemonic: v.string(),
+  readings: v.array(KanjiReading),
+  visually_similar_subject_ids: v.array(v.number()),
+});
+
+/**
+ * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
+ * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
+ * differently than the common attribute of the same name.
+ *
+ * This type asserts the subject type is a kanji.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Resources
+ * @category Subjects
+ */
+export interface Kanji extends BaseResource {
+  /**
+   * Data for the returned kanji.
+   */
+  data: KanjiData;
+
+  /**
+   * A unique number identifying the kanji.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "kanji";
+}
+export const Kanji = v.object({
+  ...BaseResource.entries,
+  data: KanjiData,
+  id: v.number(),
+  object: v.literal("kanji"),
+});
+
+/**
+ * A collection of kanji subjects returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
+ * @category Collections
+ * @category Subjects
+ */
+export interface KanjiCollection extends BaseCollection {
+  /**
+   * An array of returned kanji subjects.
+   */
+  data: Kanji[];
+}
+export const KanjiCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Kanji),
+});
 
 /**
  * Japanese context sentences for vocabulary, with a corresponding English translation.
@@ -679,7 +408,7 @@ export interface WKVocabularyCollection extends WKCollection {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface WKVocabularyContextSentence {
+export interface VocabularyContextSentence {
   /**
    * English translation of the sentence.
    */
@@ -690,76 +419,10 @@ export interface WKVocabularyContextSentence {
    */
   ja: string;
 }
-
-/**
- * Data returned only for vocabulary subjects.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Data
- * @category Subjects
- */
-export interface WKVocabularyData extends WKSubjectData {
-  /**
-   * The UTF-8 characters for the subject, including kanji and hiragana.
-   */
-  characters: string;
-
-  /**
-   * An array of numeric identifiers for the kanji that make up this vocabulary. Note that these are the subjects that
-   * must be have passed assignments in order to unlock this subject's assignment.
-   */
-  component_subject_ids: number[];
-
-  /**
-   * A collection of context sentences.
-   */
-  context_sentences: WKVocabularyContextSentence[];
-
-  /**
-   * Parts of speech.
-   */
-  parts_of_speech: string[];
-
-  /**
-   * A collection of pronunciation audio.
-   */
-  pronunciation_audios: WKVocabularyPronunciationAudio[];
-
-  /**
-   * The vocabulary's reading mnemonic.
-   */
-  reading_mnemonic: string;
-
-  /**
-   * Selected readings for the vocabulary.
-   */
-  readings: WKVocabularyReading[];
-
-  /**
-   * Vocabulary subjects will never have an `amalgamation_subject_ids` property defined.
-   */
-  amalgamation_subject_ids?: never;
-
-  /**
-   * Vocabulary subjects will never have a `character_images` property defined.
-   */
-  character_images?: never;
-
-  /**
-   * Vocabulary subjects will never have a `meaning_hint` property defined.
-   */
-  meaning_hint?: never;
-
-  /**
-   * Vocabulary subjects will never have a `reading_hint` property defined.
-   */
-  reading_hint?: never;
-
-  /**
-   * Vocabulary subjects will never have a `visually_similar_subject_ids` property defined.
-   */
-  visually_similar_subject_ids?: never;
-}
+export const VocabularyContextSentence = v.object({
+  en: v.string(),
+  ja: v.string(),
+});
 
 /**
  * Information pertaining to pronunciation audio for a vocabulary subject.
@@ -767,7 +430,7 @@ export interface WKVocabularyData extends WKSubjectData {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface WKVocabularyPronunciationAudio {
+export interface VocabularyPronunciationAudio {
   /**
    * The content type of the audio. Currently the API delivers `audio/mpeg`, `audio/ogg`, and `audio/webm`.
    */
@@ -813,6 +476,18 @@ export interface WKVocabularyPronunciationAudio {
    */
   url: string;
 }
+export const VocabularyPronunciationAudio = v.object({
+  content_type: v.picklist(["audio/mpeg", "audio/ogg", "audio/webm"]),
+  metadata: v.object({
+    gender: v.picklist(["female", "male"]),
+    pronunciation: v.string(),
+    source_id: v.number(),
+    voice_actor_id: v.number(),
+    voice_actor_name: v.string(),
+    voice_description: v.string(),
+  }),
+  url: v.string(),
+});
 
 /**
  * Information pertaining to a reading of a vocabulary subject..
@@ -820,7 +495,7 @@ export interface WKVocabularyPronunciationAudio {
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface WKVocabularyReading {
+export interface VocabularyReading {
   /**
    * Indicates if the reading is used to evaluate user input for correctness.
    */
@@ -835,12 +510,351 @@ export interface WKVocabularyReading {
    * A singular subject reading.
    */
   reading: string;
+}
+export const VocabularyReading = v.object({
+  accepted_answer: v.boolean(),
+  primary: v.boolean(),
+  reading: v.string(),
+});
+
+/**
+ * Data returned only for vocabulary subjects.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Data
+ * @category Subjects
+ */
+export interface VocabularyData extends SubjectBaseData {
+  /**
+   * The UTF-8 characters for the subject, including kanji and hiragana.
+   */
+  characters: string;
 
   /**
-   * Vocabulary readings will never have a reading `type`.
+   * An array of numeric identifiers for the kanji that make up this vocabulary. Note that these are the subjects that
+   * must be have passed assignments in order to unlock this subject's assignment.
    */
-  type?: never;
+  component_subject_ids: number[];
+
+  /**
+   * A collection of context sentences.
+   */
+  context_sentences: VocabularyContextSentence[];
+
+  /**
+   * Parts of speech.
+   */
+  parts_of_speech: string[];
+
+  /**
+   * A collection of pronunciation audio.
+   */
+  pronunciation_audios: VocabularyPronunciationAudio[];
+
+  /**
+   * The vocabulary's reading mnemonic.
+   */
+  reading_mnemonic: string;
+
+  /**
+   * Selected readings for the vocabulary.
+   */
+  readings: VocabularyReading[];
 }
+export const VocabularyData = v.object({
+  ...SubjectBaseData.entries,
+  characters: v.string(),
+  component_subject_ids: v.array(v.number()),
+  context_sentences: v.array(VocabularyContextSentence),
+  parts_of_speech: v.array(v.string()),
+  pronunciation_audios: v.array(VocabularyPronunciationAudio),
+  reading_mnemonic: v.string(),
+  readings: v.array(VocabularyReading),
+});
+
+/**
+ * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
+ * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
+ * differently than the common attribute of the same name.
+ *
+ * This type asserts the subject type is a vocabulary subject.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Resources
+ * @category Subjects
+ */
+export interface Vocabulary extends BaseResource {
+  /**
+   * Data for the returned vocabulary.
+   */
+  data: VocabularyData;
+
+  /**
+   * A unique number identifying the vocabulary.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "vocabulary";
+}
+export const Vocabulary = v.object({
+  ...BaseResource.entries,
+  data: VocabularyData,
+  id: v.number(),
+  object: v.literal("vocabulary"),
+});
+
+/**
+ * A collection of vocabulary subjects returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
+ * @category Collections
+ * @category Subjects
+ */
+export interface VocabularyCollection extends BaseCollection {
+  /**
+   * An array of returned vocabulary subjects.
+   */
+  data: Vocabulary[];
+}
+export const VocabularyCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Vocabulary),
+});
+
+/**
+ * Data returned only for kana-only vocabulary subjects.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Data
+ * @category Subjects
+ */
+export interface KanaVocabularyData extends SubjectBaseData {
+  /**
+   * The UTF-8 characters for the subject, including kanji and hiragana.
+   */
+  characters: string;
+
+  /**
+   * A collection of context sentences.
+   */
+  context_sentences: VocabularyContextSentence[];
+
+  /**
+   * Parts of speech.
+   */
+  parts_of_speech: string[];
+
+  /**
+   * A collection of pronunciation audio.
+   */
+  pronunciation_audios: VocabularyPronunciationAudio[];
+}
+export const KanaVocabularyData = v.object({
+  ...SubjectBaseData.entries,
+  characters: v.string(),
+  context_sentences: v.array(VocabularyContextSentence),
+  parts_of_speech: v.array(v.string()),
+  pronunciation_audios: v.array(VocabularyPronunciationAudio),
+});
+
+/**
+ * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
+ * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
+ * differently than the common attribute of the same name.
+ *
+ * This type asserts the subject type is a kana-only vocabulary subject.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Resources
+ * @category Subjects
+ */
+export interface KanaVocabulary extends BaseResource {
+  /**
+   * Data for the returned kana-only vocabulary.
+   */
+  data: KanaVocabularyData;
+
+  /**
+   * A unique number identifying the kana-only vocabulary.
+   */
+  id: number;
+
+  /**
+   * The kind of object returned.
+   */
+  object: "kana_vocabulary";
+}
+export const KanaVocabulary = v.object({
+  ...BaseResource.entries,
+  data: KanaVocabularyData,
+  id: v.number(),
+  object: v.literal("kana_vocabulary"),
+});
+
+/**
+ * A collection of kana-only vocabulary subjects returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
+ * @category Collections
+ * @category Subjects
+ */
+export interface KanaVocabularyCollection extends BaseCollection {
+  /**
+   * An array of returned vocabulary subjects.
+   */
+  data: KanaVocabulary[];
+}
+export const KanaVocabularyCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(KanaVocabulary),
+});
+
+/**
+ * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
+ * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
+ * differently than the common attribute of the same name.
+ *
+ * This type is for mixed or unknown subject types; it is a discriminated union based on the subject's `object` key.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Resources
+ * @category Subjects
+ */
+export type Subject = BaseResource & {
+  /**
+   * A unique number identifying the subject.
+   */
+  id: number;
+} & (
+    | {
+        /**
+         * Data for the returned kana-only vocabulary.
+         */
+        data: KanaVocabularyData;
+
+        /**
+         * The kind of object returned.
+         */
+        object: "kana_vocabulary";
+      }
+    | {
+        /**
+         * Data for the returned kanji.
+         */
+        data: KanjiData;
+
+        /**
+         * The kind of object returned.
+         */
+        object: "kanji";
+      }
+    | {
+        /**
+         * Data for the returned radical.
+         */
+        data: RadicalData;
+
+        /**
+         * The kind of object returned.
+         */
+        object: "radical";
+      }
+    | {
+        /**
+         * Data for the returned vocabulary.
+         */
+        data: VocabularyData;
+
+        /**
+         * The kind of object returned.
+         */
+        object: "vocabulary";
+      }
+  );
+export const Subject = v.intersect([
+  BaseResource,
+  v.object({
+    id: v.number(),
+  }),
+  v.variant("object", [
+    v.object({
+      data: KanaVocabularyData,
+      object: v.literal("kana_vocabulary"),
+    }),
+    v.object({
+      data: KanjiData,
+      object: v.literal("kanji"),
+    }),
+    v.object({
+      data: RadicalData,
+      object: v.literal("radical"),
+    }),
+    v.object({
+      data: VocabularyData,
+      object: v.literal("vocabulary"),
+    }),
+  ]),
+]);
+
+/**
+ * A collection of subjects of mixed or unknown types returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
+ * @category Collections
+ * @category Subjects
+ */
+export interface SubjectCollection extends BaseCollection {
+  /**
+   * An array of returned subjects of mixed or unknown type.
+   */
+  data: Subject[];
+}
+export const SubjectCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(Subject),
+});
+
+/**
+ * A set of regular expression literals that match to various markup patterns in a Subject's Meaning/Reading Mnemonics
+ * and Hints.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Subjects
+ */
+export const WK_SUBJECT_MARKUP_MATCHERS = {
+  /**
+   * A regular expression literal that matches to Japanese text surrounded by `<ja>` tags.
+   */
+  ja: /<ja>(?<innerText>.+?)<\/ja>/gu,
+
+  /**
+   * A regular expression literal that matches to Japanese kanji surrounded by `<kanji>` tags.
+   */
+  kanji: /<kanji>(?<innerText>.+?)<\/kanji>/gu,
+
+  /**
+   * A regular expression literal that matches to a subject meaning surrounded by `<meaning>` tags.
+   */
+  meaning: /<meaning>(?<innerText>.+?)<\/meaning>/gu,
+
+  /**
+   * A regular expression literal that matches to WaniKani Radical names surrounded by `<radical>` tags.
+   */
+  radical: /<radical>(?<innerText>.+?)<\/radical>/gu,
+
+  /**
+   * A regular expression literal that matches to a kanji/vocabulary reading surrounded by `<reading>` tags.
+   */
+  reading: /<reading>(?<innerText>.+?)<\/reading>/gu,
+
+  /**
+   * A regular expression literal that matches to WaniKani Vocabulary surrounded by `<vocabulary>` tags.
+   */
+  vocabulary: /<vocabulary>(?<innerText>.+?)<\/vocabulary>/gu,
+} as const;
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Subject Collection.
@@ -871,11 +885,10 @@ export interface SubjectParameters extends CollectionParameters {
    */
   types?: SubjectTuple;
 }
-export const SubjectParameters = extendCollectionParameters(
-  v.object({
-    hidden: v.optional(v.boolean()),
-    levels: v.optional(v.array(Level)),
-    slugs: v.optional(v.array(v.string())),
-    types: v.optional(SubjectTuple),
-  }),
-);
+export const SubjectParameters = v.object({
+  ...CollectionParameters.entries,
+  hidden: v.optional(v.boolean()),
+  levels: v.optional(v.array(Level)),
+  slugs: v.optional(v.array(v.string())),
+  types: v.optional(SubjectTuple),
+});

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -143,34 +143,58 @@ export const SubjectBaseData = v.object({
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
  * @category Subjects
  */
-export interface RadicalCharacterImage {
-  /**
-   * The content type of the image.
-   */
-  content_type: "image/svg+xml";
-
-  /**
-   * Details about the image. Each `content_type` returns a uniquely structured object.
-   */
-  metadata: {
-    /**
-     * The SVG asset contains built-in CSS styling.
-     */
-    inline_styles: boolean;
-  };
-
+export type RadicalCharacterImage = {
   /**
    * The location of the image.
    */
   url: string;
-}
-export const RadicalCharacterImage = v.object({
-  content_type: v.literal("image/svg+xml"),
-  metadata: v.object({
-    inline_styles: v.boolean(),
+} & (
+  | {
+      /**
+       * The content type of the image.
+       */
+      content_type: "image/svg+xml";
+
+      /**
+       * Details about the image. Each `content_type` returns a uniquely structured object.
+       */
+      metadata: {
+        /**
+         * The SVG asset contains built-in CSS styling.
+         */
+        inline_styles: boolean;
+      };
+    }
+  | {
+      content_type: "image/png";
+      metadata: {
+        color: string;
+        dimensions: string;
+        style_name: string;
+      };
+    }
+);
+export const RadicalCharacterImage = v.intersect([
+  v.object({
+    url: v.string(),
   }),
-  url: v.string(),
-});
+  v.variant("content_type", [
+    v.object({
+      content_type: v.literal("image/svg+xml"),
+      metadata: v.object({
+        inline_styles: v.boolean(),
+      }),
+    }),
+    v.object({
+      content_type: v.literal("image/png"),
+      metadata: v.object({
+        color: v.string(),
+        dimensions: v.string(),
+        style_name: v.string(),
+      }),
+    }),
+  ]),
+]);
 
 /**
  * Data returned only for radical subjects.

--- a/src/summary/v20170710.ts
+++ b/src/summary/v20170710.ts
@@ -1,43 +1,5 @@
-import type { DatableString, WKReport } from "../base/v20170710.js";
-
-/**
- * The summary report contains currently available lessons and reviews and the reviews that will become available in the
- * next 24 hours, grouped by the hour.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#summary}
- * @category Reports
- * @category Summary
- */
-export interface WKSummary extends WKReport {
-  /**
-   * Data for the Summary report.
-   */
-  data: WKSummaryData;
-}
-
-/**
- * Data for the Summary report returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#summary}
- * @category Data
- * @category Summary
- */
-export interface WKSummaryData {
-  /**
-   * Details about subjects available for lessons.
-   */
-  lessons: WKSummaryLesson[];
-
-  /**
-   * Earliest date when the reviews are available. Is `null` when the user has no reviews scheduled.
-   */
-  next_reviews_at: DatableString | null;
-
-  /**
-   * Details about subjects available for reviews now and in the next 24 hours by the hour (total of 25 objects).
-   */
-  reviews: WKSummaryReview[];
-}
+import * as v from "valibot";
+import { BaseReport, DatableString } from "../base/v20170710.js";
 
 /**
  * Details about subjects listed as available for lessons in the Summary report.
@@ -45,7 +7,7 @@ export interface WKSummaryData {
  * @see {@link https://docs.api.wanikani.com/20170710/#summary}
  * @category Summary
  */
-export interface WKSummaryLesson {
+export interface SummaryInterval {
   /**
    * When the paired `subject_ids` are available for lessons. Always beginning of the current hour when the API endpoint
    * is accessed.
@@ -57,21 +19,55 @@ export interface WKSummaryLesson {
    */
   subject_ids: number[];
 }
+export const SummaryInterval = v.object({
+  available_at: DatableString,
+  subject_ids: v.array(v.number()),
+});
 
 /**
- * Details about subjects listed as available for reviews in the Summary report.
+ * Data for the Summary report returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#summary}
+ * @category Data
  * @category Summary
  */
-export interface WKSummaryReview {
+export interface SummaryData {
   /**
-   * When the paired `subject_ids` are available for reviews. All timestamps are the top of an hour.
+   * Details about subjects available for lessons.
    */
-  available_at: DatableString;
+  lessons: SummaryInterval[];
 
   /**
-   * Collection of unique identifiers for subjects.
+   * Earliest date when the reviews are available. Is `null` when the user has no reviews scheduled.
    */
-  subject_ids: number[];
+  next_reviews_at: DatableString | null;
+
+  /**
+   * Details about subjects available for reviews now and in the next 24 hours by the hour (total of 25 objects).
+   */
+  reviews: SummaryInterval[];
 }
+export const SummaryData = v.object({
+  lessons: v.array(SummaryInterval),
+  next_reviews_at: v.union([DatableString, v.null()]),
+  reviews: v.array(SummaryInterval),
+});
+
+/**
+ * The summary report contains currently available lessons and reviews and the reviews that will become available in the
+ * next 24 hours, grouped by the hour.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#summary}
+ * @category Reports
+ * @category Summary
+ */
+export interface Summary extends BaseReport {
+  /**
+   * Data for the Summary report.
+   */
+  data: SummaryData;
+}
+export const Summary = v.object({
+  ...BaseReport.entries,
+  data: SummaryData,
+});

--- a/src/v20170710.ts
+++ b/src/v20170710.ts
@@ -8,7 +8,6 @@ export * from "./reviews/v20170710.js";
 export * from "./spaced-repetition-systems/v20170710.js";
 export * from "./study-materials/v20170710.js";
 export * from "./subjects/v20170710.js";
-// TODO: Review if anything besides types needs exporting
-export type * from "./summary/v20170710.js";
+export * from "./summary/v20170710.js";
 export * from "./user/v20170710.js";
 export * from "./voice-actors/v20170710.js";

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -1,4 +1,40 @@
-import { CollectionParameters, type DatableString, type WKCollection, type WKResource } from "../base/v20170710.js";
+import * as v from "valibot";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
+
+/**
+ * Data for a voice actor returned from the WaniKani API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#voice-actors}
+ * @category Data
+ * @category Voice Actors
+ */
+export interface VoiceActorData {
+  /**
+   * Timestamp for when the voice actor was added to WaniKani.
+   */
+  created_at: DatableString;
+
+  /**
+   * Details about the voice actor.
+   */
+  description: string;
+
+  /**
+   * The voice actor's gender, either `male` or `female`.
+   */
+  gender: "female" | "male";
+
+  /**
+   * The voice actor's name.
+   */
+  name: string;
+}
+export const VoiceActorData = v.object({
+  created_at: DatableString,
+  description: v.string(),
+  gender: v.picklist(["female", "male"]),
+  name: v.string(),
+});
 
 /**
  * Available voice actors used for vocabulary reading pronunciation audio.
@@ -7,11 +43,11 @@ import { CollectionParameters, type DatableString, type WKCollection, type WKRes
  * @category Resources
  * @category Voice Actors
  */
-export interface WKVoiceActor extends WKResource {
+export interface VoiceActor extends BaseResource {
   /**
    * Data for the returned voice actor.
    */
-  data: WKVoiceActorData;
+  data: VoiceActorData;
 
   /**
    * A unique number identifying the voice actor.
@@ -23,6 +59,12 @@ export interface WKVoiceActor extends WKResource {
    */
   object: "voice_actor";
 }
+export const VoiceActor = v.object({
+  ...BaseResource.entries,
+  data: VoiceActorData,
+  id: v.number(),
+  object: v.literal("voice_actor"),
+});
 
 /**
  * A collection of voice actors returned from the WaniKani API.
@@ -31,40 +73,16 @@ export interface WKVoiceActor extends WKResource {
  * @category Collections
  * @category Voice Actors
  */
-export interface WKVoiceActorCollection extends WKCollection {
+export interface VoiceActorCollection extends BaseCollection {
   /**
    * An array of returned voice actors.
    */
-  data: WKVoiceActor[];
+  data: VoiceActor[];
 }
-
-/**
- * Data for a voice actor returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#voice-actors}
- * @category Data
- * @category Voice Actors
- */
-export interface WKVoiceActorData {
-  /**
-   * Timestamp for when the voice actor was added to WaniKani.
-   */
-  created_at: DatableString;
-
-  /**
-   * Details about the voice actor.
-   */
-  description: string;
-  /**
-   * The voice actor's gender, either `male` or `female`.
-   */
-  gender: "female" | "male";
-
-  /**
-   * The voice actor's name.
-   */
-  name: string;
-}
+export const VoiceActorCollection = v.object({
+  ...BaseCollection.entries,
+  data: v.array(VoiceActor),
+});
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Voice Actor Collection.

--- a/tests/assignments/v20170710.test-d.ts
+++ b/tests/assignments/v20170710.test-d.ts
@@ -1,4 +1,3 @@
-import { assertType, describe } from "vitest";
 import type {
   Assignment,
   AssignmentCollection,
@@ -6,10 +5,11 @@ import type {
   AssignmentParameters,
   AssignmentPayload,
 } from "../../src/assignments/v20170710.js";
+import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("AssignmentData", () => {
-  testFor("Real AssignmentData", ({ assignmentData, assignment }) => {
+  testFor("Real AssignmentData", ({ assignmentData }) => {
     assertType<AssignmentData>(assignmentData);
   });
 });

--- a/tests/assignments/v20170710.test-d.ts
+++ b/tests/assignments/v20170710.test-d.ts
@@ -1,18 +1,11 @@
 import type {
   Assignment,
   AssignmentCollection,
-  AssignmentData,
   AssignmentParameters,
   AssignmentPayload,
 } from "../../src/assignments/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("AssignmentData", () => {
-  testFor("Real AssignmentData", ({ assignmentData }) => {
-    assertType<AssignmentData>(assignmentData);
-  });
-});
 
 describe("Assignment", () => {
   testFor("Real Assignment", ({ assignment }) => {

--- a/tests/assignments/v20170710.test-d.ts
+++ b/tests/assignments/v20170710.test-d.ts
@@ -1,0 +1,57 @@
+import { describe, expectTypeOf } from "vitest";
+import type {
+  Assignment,
+  AssignmentCollection,
+  AssignmentData,
+  AssignmentParameters,
+  AssignmentPayload,
+} from "../../src/assignments/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("AssignmentData", () => {
+  testFor("Real AssignmentData", ({ assignmentData }) => {
+    expectTypeOf<AssignmentData>(assignmentData).toEqualTypeOf<AssignmentData>();
+  });
+});
+
+describe("Assignment", () => {
+  testFor("Real Assignment", ({ assignment }) => {
+    expectTypeOf<Assignment>(assignment).toEqualTypeOf<Assignment>();
+  });
+});
+
+describe("AssignmentCollection", () => {
+  testFor("Real AssignmentCollection", ({ assignmentCollection }) => {
+    expectTypeOf<AssignmentCollection>(assignmentCollection).toEqualTypeOf<AssignmentCollection>();
+  });
+});
+
+describe("AssignmentParameters", () => {
+  testFor("Empty AssignmentParameters", ({ emptyParams }) => {
+    expectTypeOf<AssignmentParameters>(emptyParams).toEqualTypeOf<AssignmentParameters>();
+  });
+  testFor("AssignmentParameters with empty arrays", ({ assignmentParamsWithEmptyArrays }) => {
+    expectTypeOf<AssignmentParameters>(assignmentParamsWithEmptyArrays).toEqualTypeOf<AssignmentParameters>();
+  });
+  testFor("AssignmentParameters with many options filled", ({ assignmentParamsWithManyOptions }) => {
+    expectTypeOf<AssignmentParameters>(assignmentParamsWithManyOptions).toEqualTypeOf<AssignmentParameters>();
+  });
+  testFor("AssignmentParameters with Date objects", ({ assignmentParamsWithDates }) => {
+    expectTypeOf<AssignmentParameters>(assignmentParamsWithDates).toEqualTypeOf<AssignmentParameters>();
+  });
+  testFor("AssignmentParameters with DatableString properties", ({ assignmentParamsWithDatableStrings }) => {
+    expectTypeOf<AssignmentParameters>(assignmentParamsWithDatableStrings).toEqualTypeOf<AssignmentParameters>();
+  });
+});
+
+describe("AssignmentPayload", () => {
+  testFor("AssignmentPayload with empty assignment property", ({ assignmentPayloadWithNoTime }) => {
+    expectTypeOf<AssignmentPayload>(assignmentPayloadWithNoTime).toEqualTypeOf<AssignmentPayload>();
+  });
+  testFor("AssignmentPayload with JS Date started_at property", ({ assignmentPayloadWithDate }) => {
+    expectTypeOf<AssignmentPayload>(assignmentPayloadWithDate).toEqualTypeOf<AssignmentPayload>();
+  });
+  testFor("AssignmentPayload with DatableString started_at property", ({ assignmentPayloadWithDatableString }) => {
+    expectTypeOf<AssignmentPayload>(assignmentPayloadWithDatableString).toEqualTypeOf<AssignmentPayload>();
+  });
+});

--- a/tests/assignments/v20170710.test-d.ts
+++ b/tests/assignments/v20170710.test-d.ts
@@ -1,4 +1,4 @@
-import { describe, expectTypeOf } from "vitest";
+import { assertType, describe } from "vitest";
 import type {
   Assignment,
   AssignmentCollection,
@@ -9,49 +9,49 @@ import type {
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("AssignmentData", () => {
-  testFor("Real AssignmentData", ({ assignmentData }) => {
-    expectTypeOf<AssignmentData>(assignmentData).toEqualTypeOf<AssignmentData>();
+  testFor("Real AssignmentData", ({ assignmentData, assignment }) => {
+    assertType<AssignmentData>(assignmentData);
   });
 });
 
 describe("Assignment", () => {
   testFor("Real Assignment", ({ assignment }) => {
-    expectTypeOf<Assignment>(assignment).toEqualTypeOf<Assignment>();
+    assertType<Assignment>(assignment);
   });
 });
 
 describe("AssignmentCollection", () => {
   testFor("Real AssignmentCollection", ({ assignmentCollection }) => {
-    expectTypeOf<AssignmentCollection>(assignmentCollection).toEqualTypeOf<AssignmentCollection>();
+    assertType<AssignmentCollection>(assignmentCollection);
   });
 });
 
 describe("AssignmentParameters", () => {
   testFor("Empty AssignmentParameters", ({ emptyParams }) => {
-    expectTypeOf<AssignmentParameters>(emptyParams).toEqualTypeOf<AssignmentParameters>();
+    assertType<AssignmentParameters>(emptyParams);
   });
   testFor("AssignmentParameters with empty arrays", ({ assignmentParamsWithEmptyArrays }) => {
-    expectTypeOf<AssignmentParameters>(assignmentParamsWithEmptyArrays).toEqualTypeOf<AssignmentParameters>();
+    assertType<AssignmentParameters>(assignmentParamsWithEmptyArrays);
   });
   testFor("AssignmentParameters with many options filled", ({ assignmentParamsWithManyOptions }) => {
-    expectTypeOf<AssignmentParameters>(assignmentParamsWithManyOptions).toEqualTypeOf<AssignmentParameters>();
+    assertType<AssignmentParameters>(assignmentParamsWithManyOptions);
   });
   testFor("AssignmentParameters with Date objects", ({ assignmentParamsWithDates }) => {
-    expectTypeOf<AssignmentParameters>(assignmentParamsWithDates).toEqualTypeOf<AssignmentParameters>();
+    assertType<AssignmentParameters>(assignmentParamsWithDates);
   });
   testFor("AssignmentParameters with DatableString properties", ({ assignmentParamsWithDatableStrings }) => {
-    expectTypeOf<AssignmentParameters>(assignmentParamsWithDatableStrings).toEqualTypeOf<AssignmentParameters>();
+    assertType<AssignmentParameters>(assignmentParamsWithDatableStrings);
   });
 });
 
 describe("AssignmentPayload", () => {
   testFor("AssignmentPayload with empty assignment property", ({ assignmentPayloadWithNoTime }) => {
-    expectTypeOf<AssignmentPayload>(assignmentPayloadWithNoTime).toEqualTypeOf<AssignmentPayload>();
+    assertType<AssignmentPayload>(assignmentPayloadWithNoTime);
   });
   testFor("AssignmentPayload with JS Date started_at property", ({ assignmentPayloadWithDate }) => {
-    expectTypeOf<AssignmentPayload>(assignmentPayloadWithDate).toEqualTypeOf<AssignmentPayload>();
+    assertType<AssignmentPayload>(assignmentPayloadWithDate);
   });
   testFor("AssignmentPayload with DatableString started_at property", ({ assignmentPayloadWithDatableString }) => {
-    expectTypeOf<AssignmentPayload>(assignmentPayloadWithDatableString).toEqualTypeOf<AssignmentPayload>();
+    assertType<AssignmentPayload>(assignmentPayloadWithDatableString);
   });
 });

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -1,5 +1,4 @@
 import * as v from "valibot";
-import { expect, describe } from "vitest";
 import {
   Assignment,
   AssignmentCollection,
@@ -7,6 +6,7 @@ import {
   AssignmentParameters,
   AssignmentPayload,
 } from "../../src/assignments/v20170710.js";
+import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("AssignmentData", () => {

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -7,7 +7,6 @@ import {
   AssignmentParameters,
   AssignmentPayload,
 } from "../../src/assignments/v20170710.js";
-import { DatableString } from "../../src/base/v20170710.js";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("AssignmentData", () => {

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -2,18 +2,11 @@ import * as v from "valibot";
 import {
   Assignment,
   AssignmentCollection,
-  AssignmentData,
   AssignmentParameters,
   AssignmentPayload,
 } from "../../src/assignments/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("AssignmentData", () => {
-  testFor("Real AssignmentData", ({ assignmentData }) => {
-    expect(() => v.assert(AssignmentData, assignmentData)).not.toThrow();
-  });
-});
 
 describe("Assignment", () => {
   testFor("Real Assignment", ({ assignment }) => {

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -1,80 +1,59 @@
 import * as v from "valibot";
-import { expect, describe, test } from "vitest";
-import { AssignmentParameters, AssignmentPayload } from "../../src/assignments/v20170710";
+import { expect, describe } from "vitest";
+import {
+  Assignment,
+  AssignmentCollection,
+  AssignmentData,
+  AssignmentParameters,
+  AssignmentPayload,
+} from "../../src/assignments/v20170710";
 import { DatableString } from "../../src/base/v20170710";
+import { testFor } from "../fixtures/v20170710";
+
+describe("AssignmentData", () => {
+  testFor("Real AssignmentData", ({ assignmentData }) => {
+    expect(() => v.assert(AssignmentData, assignmentData)).not.toThrow();
+  });
+});
+
+describe("Assignment", () => {
+  testFor("Real Assignment", ({ assignment }) => {
+    expect(() => v.assert(Assignment, assignment)).not.toThrow();
+  });
+});
+
+describe("AssignmentCollection", () => {
+  testFor("Real AssignmentCollection", ({ assignmentCollection }) => {
+    expect(() => v.assert(AssignmentCollection, assignmentCollection)).not.toThrow();
+  });
+});
 
 describe("AssignmentParameters", () => {
-  test("Empty AssignmentParameters", () => {
-    const params1: AssignmentParameters = {};
-    expect(() => v.parse(AssignmentParameters, params1)).not.toThrow();
+  testFor("Empty AssignmentParameters", ({ emptyParams }) => {
+    expect(() => v.assert(AssignmentParameters, emptyParams)).not.toThrow();
   });
-  test("AssignmentParameters with empty arrays", () => {
-    const params2: AssignmentParameters = {
-      ids: [],
-      levels: [],
-      srs_stages: [],
-      subject_ids: [],
-    };
-    expect(() => v.parse(AssignmentParameters, params2)).not.toThrow();
+  testFor("AssignmentParameters with empty arrays", ({ assignmentParamsWithEmptyArrays }) => {
+    expect(() => v.assert(AssignmentParameters, assignmentParamsWithEmptyArrays)).not.toThrow();
   });
-  test("AssignmentParameters with many options filled", () => {
-    const params3: AssignmentParameters = {
-      ids: [1, 2, 3],
-      page_after_id: 1,
-      page_before_id: 1,
-      burned: true,
-      hidden: false,
-      immediately_available_for_lessons: true,
-      immediately_available_for_review: false,
-      in_review: true,
-      levels: [1, 2, 3],
-      srs_stages: [1, 2, 3],
-      started: true,
-      subject_ids: [1, 2, 3],
-      subject_types: ["kana_vocabulary", "vocabulary"],
-      unlocked: true,
-    };
-    expect(() => v.parse(AssignmentParameters, params3)).not.toThrow();
+  testFor("AssignmentParameters with many options filled", ({ assignmentParamsWithManyOptions }) => {
+    expect(() => v.assert(AssignmentParameters, assignmentParamsWithManyOptions)).not.toThrow();
   });
-  test("AssignmentParameters with Date objects", () => {
-    const params4: AssignmentParameters = {
-      available_after: new Date(),
-      available_before: new Date(),
-      updated_after: new Date(),
-    };
-    expect(() => v.parse(AssignmentParameters, params4)).not.toThrow();
+  testFor("AssignmentParameters with Date objects", ({ assignmentParamsWithDates }) => {
+    expect(() => v.assert(AssignmentParameters, assignmentParamsWithDates)).not.toThrow();
   });
-  test("AssignmentParameters with DatableString properties", () => {
-    const params5: AssignmentParameters = {
-      available_after: v.parse(DatableString, new Date().toISOString()),
-      available_before: v.parse(DatableString, new Date().toISOString()),
-      updated_after: v.parse(DatableString, new Date().toISOString()),
-    };
-    expect(() => v.parse(AssignmentParameters, params5)).not.toThrow();
+  testFor("AssignmentParameters with DatableString properties", ({ assignmentParamsWithDatableStrings }) => {
+    expect(() => v.assert(AssignmentParameters, assignmentParamsWithDatableStrings)).not.toThrow();
   });
 });
 
 describe("AssignmentPayload", () => {
-  test("AssignmentPayload with empty assignment property", () => {
-    const payload1: AssignmentPayload = {
-      assignment: {},
-    };
-    expect(() => v.parse(AssignmentPayload, payload1)).not.toThrow();
+  testFor("AssignmentPayload with empty assignment property", ({ assignmentPayloadWithNoTime }) => {
+    expect(() => v.assert(AssignmentPayload, assignmentPayloadWithNoTime)).not.toThrow();
   });
-  test("AssignmentPayload with JS Date started_at property", () => {
-    const payload2: AssignmentPayload = {
-      assignment: {
-        started_at: new Date(),
-      },
-    };
-    expect(() => v.parse(AssignmentPayload, payload2)).not.toThrow();
+  testFor("AssignmentPayload with JS Date started_at property", ({ assignmentPayloadWithDate }) => {
+    expect(() => v.assert(AssignmentPayload, assignmentPayloadWithDate)).not.toThrow();
   });
-  test("AssignmentPayload with DatableString started_at property", () => {
-    const payload3: AssignmentPayload = {
-      assignment: {
-        started_at: v.parse(DatableString, "2024-12-27T15:32:23.000Z"),
-      },
-    };
-    expect(() => v.parse(AssignmentPayload, payload3)).not.toThrow();
+  testFor("AssignmentPayload with DatableString started_at property", ({ assignmentPayloadWithDatableString }) => {
+    expect(() => v.assert(AssignmentPayload, assignmentPayloadWithDatableString)).not.toThrow();
   });
 });

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -6,9 +6,9 @@ import {
   AssignmentData,
   AssignmentParameters,
   AssignmentPayload,
-} from "../../src/assignments/v20170710";
-import { DatableString } from "../../src/base/v20170710";
-import { testFor } from "../fixtures/v20170710";
+} from "../../src/assignments/v20170710.js";
+import { DatableString } from "../../src/base/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
 
 describe("AssignmentData", () => {
   testFor("Real AssignmentData", ({ assignmentData }) => {

--- a/tests/base/v20170710.test-d.ts
+++ b/tests/base/v20170710.test-d.ts
@@ -1,0 +1,95 @@
+import type * as v from "valibot";
+import {
+  type ApiRevision,
+  type CollectionParameters,
+  type DatableString,
+  type Level,
+  type ResourceType,
+  type SubjectTuple,
+  type SubjectType,
+  stringifyParameters,
+} from "../../src/base/v20170710.js";
+import { assertType, describe, expectTypeOf } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("ApiRevision", () => {
+  testFor("Valid WaniKani API Revision", ({ apiRevision }) => {
+    assertType<ApiRevision>(apiRevision);
+  });
+});
+
+describe("DatableString", () => {
+  testFor("Valid DatableString Type", () => {
+    expectTypeOf<v.InferOutput<typeof DatableString>>().toEqualTypeOf<DatableString>();
+  });
+});
+
+describe("Level", () => {
+  testFor("Valid Levels", ({ levels }) => {
+    if (Array.isArray(levels)) {
+      levels.forEach((level) => {
+        assertType<Level>(level);
+      });
+    } else {
+      throw new TypeError("Expected levels to be an array");
+    }
+  });
+});
+
+describe("ResourceType", () => {
+  testFor("Valid Resources", ({ resourceTypes }) => {
+    if (Array.isArray(resourceTypes)) {
+      resourceTypes.forEach((resource) => {
+        assertType<ResourceType>(resource);
+      });
+    } else {
+      throw new TypeError("Expected resourceTypes to be an array");
+    }
+  });
+});
+
+describe("SubjectType", () => {
+  testFor("Valid Subject Types", ({ subjectTypes }) => {
+    if (Array.isArray(subjectTypes)) {
+      subjectTypes.forEach((subject) => {
+        assertType<SubjectType>(subject);
+      });
+    } else {
+      throw new TypeError("Expected subjectTypes to be an array");
+    }
+  });
+});
+
+describe("SubjectTuple", () => {
+  // These tests are kinda redundant, but we'll leave them here for completeness' sake
+  testFor("Partial SubjectTuple is Valid", ({ partialSubjectTuple }) => {
+    assertType<SubjectTuple>(partialSubjectTuple);
+  });
+  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
+    assertType<SubjectTuple>(fullSubjectTuple);
+  });
+});
+
+describe("CollectionParameters", () => {
+  testFor("Empty CollectionParameters", ({ emptyParams }) => {
+    assertType<CollectionParameters>(emptyParams);
+  });
+  testFor("CollectionParameters with empty arrays", ({ collectionParamsWithEmptyArrays }) => {
+    assertType<CollectionParameters>(collectionParamsWithEmptyArrays);
+  });
+  testFor("CollectionParameters with many options filled", ({ collectionParamsWithManyOptions }) => {
+    assertType<CollectionParameters>(collectionParamsWithManyOptions);
+  });
+  testFor("CollectionParameters with Date objects", ({ collectionParamsWithDates }) => {
+    assertType<CollectionParameters>(collectionParamsWithDates);
+  });
+  testFor("CollectionParameters with DatableString properties", ({ collectionParamsWithDatableStrings }) => {
+    assertType<CollectionParameters>(collectionParamsWithDatableStrings);
+  });
+});
+
+describe("stringifyParameters", () => {
+  testFor("Return type is a string", ({ collectionParamsWithManyOptions }) => {
+    expectTypeOf(stringifyParameters(collectionParamsWithManyOptions)).toBeString();
+  });
+});

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -194,6 +194,8 @@ describe("stringifyParameters", () => {
   test("Throws an error when passed a non-object", () => {
     const notAnObject = "not an object";
     // @ts-expect-error
-    expect(() => stringifyParameters(notAnObject)).toThrow("Parameters must be expressed as an object.");
+    expect(() => stringifyParameters(notAnObject)).toThrow(
+      'Invalid type: Expected Object but received "not an object"',
+    );
   });
 });

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -1,159 +1,127 @@
 import * as v from "valibot";
-import { expect, describe, test } from "vitest";
 import {
   ApiRevision,
   CollectionParameters,
   DatableString,
   Level,
-  ResourceType,
-  SubjectType,
-  SubjectTuple,
   MAX_LEVEL,
   MIN_LEVEL,
+  ResourceType,
+  SubjectTuple,
+  SubjectType,
   stringifyParameters,
 } from "../../src/base/v20170710.js";
-import { AssignmentParameters } from "../../src/assignments/v20170710.js";
-import { SubjectParameters } from "../../src/subjects/v20170710.js";
+import { describe, expect } from "vitest";
+import type { AssignmentParameters } from "../../src/assignments/v20170710.js";
+import type { SubjectParameters } from "../../src/subjects/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
 
 describe("ApiRevision", () => {
-  test("Valid WaniKani API Revision", () => {
-    const apiRevision: ApiRevision = "20170710";
-    expect(() => v.parse(ApiRevision, apiRevision)).not.toThrow();
+  testFor("Valid WaniKani API Revision", ({ apiRevision }) => {
+    expect(() => v.assert(ApiRevision, apiRevision)).not.toThrow();
   });
 });
 
 describe("DatableString", () => {
-  test("Valid UTC timestamp string", () => {
-    const dateTimeUtcString = "2022-10-23T15:17:38.828455Z";
-    expect(() => v.parse(DatableString, dateTimeUtcString)).not.toThrow();
+  testFor("Valid UTC timestamp string", ({ dateTimeUtcString }) => {
+    expect(() => v.assert(DatableString, dateTimeUtcString)).not.toThrow();
   });
-  test("Valid offset timestamp string", () => {
-    const dateTimeOffsetString = "2022-10-23T15:17:38.828455+09:00";
-    expect(() => v.parse(DatableString, dateTimeOffsetString)).not.toThrow();
+  testFor("Valid offset timestamp string", ({ dateTimeOffsetString }) => {
+    expect(() => v.assert(DatableString, dateTimeOffsetString)).not.toThrow();
   });
-  test("Valid leap year timestamp string", () => {
-    const validLeapYear = "2020-02-29T12:00:00.000000Z";
-    expect(() => v.parse(DatableString, validLeapYear)).not.toThrow();
-  });
-  test("String created from Date.toISOString", () => {
-    const dateIsoString = new Date().toISOString();
-    expect(() => v.parse(DatableString, dateIsoString)).not.toThrow();
+  testFor("String created from Date.toISOString", ({ dateIsoString }) => {
+    expect(() => v.assert(DatableString, dateIsoString)).not.toThrow();
   });
 });
 
 describe("Level", () => {
-  test("Invalid Level: 0", () => {
-    expect(() => v.parse(Level, 0)).toThrow();
+  testFor(`Invalid Level: ${MIN_LEVEL - 1}`, () => {
+    expect(() => v.assert(Level, MIN_LEVEL - 1)).toThrow();
   });
-  Array<number>(MAX_LEVEL)
-    .fill(MIN_LEVEL)
-    .map((item, itemIdx) => item + itemIdx)
-    .forEach((level) => {
-      test(`Valid Level: ${level}`, () => {
-        expect(() => v.parse(Level, level)).not.toThrow();
+  testFor("Valid Levels", ({ levels }) => {
+    if (Array.isArray(levels)) {
+      levels.forEach((level) => {
+        expect(() => v.assert(Level, level)).not.toThrow();
       });
-    });
-  test(`Invalid Level: ${MAX_LEVEL + 1}`, () => {
-    expect(() => v.parse(Level, MAX_LEVEL + 1)).toThrow();
+    } else {
+      throw new TypeError("Expected levels to be an array");
+    }
+  });
+  testFor(`Invalid Level: ${MAX_LEVEL + 1}`, () => {
+    expect(() => v.assert(Level, MAX_LEVEL + 1)).toThrow();
   });
 });
 
 describe("ResourceType", () => {
-  const resourceTypes = [
-    "assignment",
-    "level_progression",
-    "reset",
-    "review_statistic",
-    "review",
-    "spaced_repetition_system",
-    "study_material",
-    "user",
-    "voice_actor",
-  ];
-  resourceTypes.forEach((resource) => {
-    test(`Valid Resource Type: ${resource}`, () => {
-      expect(() => v.parse(ResourceType, resource)).not.toThrow();
-    });
+  testFor("Valid Resource Types", ({ resourceTypes }) => {
+    if (Array.isArray(resourceTypes)) {
+      resourceTypes.forEach((resource) => {
+        expect(() => v.assert(ResourceType, resource)).not.toThrow();
+      });
+    } else {
+      throw new TypeError("Expected resourceTypes to be an array");
+    }
   });
-  test("Invalid Resource Type", () => {
-    expect(() => v.parse(ResourceType, "not real")).toThrow();
+  testFor("Invalid Resource Type", () => {
+    expect(() => v.assert(ResourceType, "not real")).toThrow();
   });
 });
 
 describe("SubjectType", () => {
-  const subjectTypes = ["kana_vocabulary", "kanji", "radical", "vocabulary"];
-  subjectTypes.forEach((subject) => {
-    test(`Valid Subject Type: ${subject}`, () => {
-      expect(() => v.parse(SubjectType, subject)).not.toThrow();
-    });
+  testFor("Valid Subject Types", ({ subjectTypes }) => {
+    if (Array.isArray(subjectTypes)) {
+      subjectTypes.forEach((subject) => {
+        expect(() => v.assert(SubjectType, subject)).not.toThrow();
+      });
+    } else {
+      throw new TypeError("Expected subjectTypes to be an array");
+    }
   });
-  test("Invalid Subject Type", () => {
-    expect(() => v.parse(SubjectType, "not real")).toThrow();
+  testFor("Invalid Subject Type", () => {
+    expect(() => v.assert(SubjectType, "not real")).toThrow();
   });
 });
 
 describe("SubjectTuple", () => {
-  test("Empty SubjectTuple throws error", () => {
-    const emptySubjectTuple: unknown[] = [];
-    expect(() => v.parse(SubjectTuple, emptySubjectTuple)).toThrow();
+  testFor("Empty SubjectTuple throws error", ({ emptySubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, emptySubjectTuple)).toThrow();
   });
-  test("Full SubjectTuple is valid", () => {
-    const fullSubjectTuple: SubjectTuple = ["kana_vocabulary", "kanji", "radical", "vocabulary"];
-    expect(() => v.parse(SubjectTuple, fullSubjectTuple)).not.toThrow();
+  testFor("Partial SubjectTuple is valid", ({ partialSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, partialSubjectTuple)).not.toThrow();
   });
-  test("SubjectTuple with repeated items throws error", () => {
-    const repeatedSubjectTuple: SubjectTuple = [
-      "kana_vocabulary",
-      "kanji",
-      "radical",
-      "kanji",
-      "vocabulary",
-      "radical",
-    ];
-    expect(() => v.parse(SubjectTuple, repeatedSubjectTuple)).toThrow();
+  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, fullSubjectTuple)).not.toThrow();
+  });
+  testFor("SubjectTuple with repeated items throws error", ({ repeatedSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, repeatedSubjectTuple)).toThrow();
   });
 });
 
 describe("CollectionParameters", () => {
-  test("Empty CollectionParameters", () => {
-    const params1: CollectionParameters = {};
-    expect(() => v.parse(CollectionParameters, params1)).not.toThrow();
+  testFor("Empty CollectionParameters", ({ emptyParams }) => {
+    expect(() => v.assert(CollectionParameters, emptyParams)).not.toThrow();
   });
-  test("CollectionParameters with empty arrays", () => {
-    const params2: CollectionParameters = {
-      ids: [],
-    };
-    expect(() => v.parse(CollectionParameters, params2)).not.toThrow();
+  testFor("CollectionParameters with empty arrays", ({ collectionParamsWithEmptyArrays }) => {
+    expect(() => v.assert(CollectionParameters, collectionParamsWithEmptyArrays)).not.toThrow();
   });
-  test("CollectionParameters with many options filled", () => {
-    const params3: CollectionParameters = {
-      ids: [1, 2, 3],
-      page_after_id: 1,
-      page_before_id: 1,
-    };
-    expect(() => v.parse(CollectionParameters, params3)).not.toThrow();
+  testFor("CollectionParameters with many options filled", ({ collectionParamsWithManyOptions }) => {
+    expect(() => v.assert(CollectionParameters, collectionParamsWithManyOptions)).not.toThrow();
   });
-  test("CollectionParameters with Date objects", () => {
-    const params4: CollectionParameters = {
-      updated_after: new Date(),
-    };
-    expect(() => v.parse(CollectionParameters, params4)).not.toThrow();
+  testFor("CollectionParameters with Date objects", ({ collectionParamsWithDates }) => {
+    expect(() => v.assert(CollectionParameters, collectionParamsWithDates)).not.toThrow();
   });
-  test("CollectionParameters with DatableString properties", () => {
-    const params5: CollectionParameters = {
-      updated_after: v.parse(DatableString, new Date().toISOString()),
-    };
-    expect(() => v.parse(CollectionParameters, params5)).not.toThrow();
+  testFor("CollectionParameters with DatableString properties", ({ collectionParamsWithDatableStrings }) => {
+    expect(() => v.assert(CollectionParameters, collectionParamsWithDatableStrings)).not.toThrow();
   });
 });
 
 describe("stringifyParameters", () => {
-  test("Properly stringifies empty objects", () => {
+  testFor("Properly stringifies empty objects", () => {
     const params: AssignmentParameters = {};
     expect(stringifyParameters(params)).toBe("");
   });
 
-  test("Properly stringifies booleans", () => {
+  testFor("Properly stringifies booleans", () => {
     const params: AssignmentParameters = {
       hidden: false,
       burned: true,
@@ -162,7 +130,7 @@ describe("stringifyParameters", () => {
     expect(stringifyParameters(params)).toBe(expectedString);
   });
 
-  test("Properly stringifies WaniKani API empty query parameters", () => {
+  testFor("Properly stringifies WaniKani API empty query parameters", () => {
     const params: AssignmentParameters = {
       immediately_available_for_lessons: true,
       immediately_available_for_review: true,
@@ -172,7 +140,7 @@ describe("stringifyParameters", () => {
     expect(stringifyParameters(params)).toBe(expectedString);
   });
 
-  test("Properly stringifies arrays", () => {
+  testFor("Properly stringifies arrays", () => {
     const params: SubjectParameters = {
       ids: [1, 2, 3, 4],
       types: ["radical", "kanji"],
@@ -181,7 +149,7 @@ describe("stringifyParameters", () => {
     expect(stringifyParameters(params)).toBe(expectedString);
   });
 
-  test("Properly stringifies dates", () => {
+  testFor("Properly stringifies dates", () => {
     const datableString = v.parse(DatableString, "2022-10-31T12:00:00.000Z");
     const params: AssignmentParameters = {
       available_after: datableString,
@@ -191,9 +159,9 @@ describe("stringifyParameters", () => {
     expect(stringifyParameters(params)).toBe(expectedString);
   });
 
-  test("Throws an error when passed a non-object", () => {
+  testFor("Throws an error when passed a non-object", () => {
     const notAnObject = "not an object";
-    // @ts-expect-error
+    // @ts-expect-error -- We pass a string instead of an object to test throwing an error
     expect(() => stringifyParameters(notAnObject)).toThrow(
       'Invalid type: Expected Object but received "not an object"',
     );

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -11,9 +11,9 @@ import {
   MAX_LEVEL,
   MIN_LEVEL,
   stringifyParameters,
-} from "../../src/base/v20170710";
-import { AssignmentParameters } from "../../src/assignments/v20170710";
-import { SubjectParameters } from "../../src/subjects/v20170710";
+} from "../../src/base/v20170710.js";
+import { AssignmentParameters } from "../../src/assignments/v20170710.js";
+import { SubjectParameters } from "../../src/subjects/v20170710.js";
 
 describe("ApiRevision", () => {
   test("Valid WaniKani API Revision", () => {
@@ -94,7 +94,7 @@ describe("SubjectType", () => {
 
 describe("SubjectTuple", () => {
   test("Empty SubjectTuple throws error", () => {
-    const emptySubjectTuple = [];
+    const emptySubjectTuple: unknown[] = [];
     expect(() => v.parse(SubjectTuple, emptySubjectTuple)).toThrow();
   });
   test("Full SubjectTuple is valid", () => {

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1027,6 +1027,34 @@ const userPayloadWithAllProperties = {
   },
 };
 
+// Voice Actors
+
+const voiceActor = {
+  id: 1,
+  object: "voice_actor" as const,
+  url: "https://api.wanikani.com/v2/voice_actors/1",
+  data_updated_at: v.parse(DatableString, "2024-11-25T00:39:22.591103Z"),
+  data: {
+    created_at: v.parse(DatableString, "2018-09-11T18:30:27.096474Z"),
+    name: "Kyoko",
+    gender: "female" as const,
+    description: "Tokyo accent",
+  },
+};
+
+const voiceActorCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/voice_actors",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 3,
+  data_updated_at: v.parse(DatableString, "2024-11-25T00:39:22.591103Z"),
+  data: [voiceActor],
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -1095,4 +1123,6 @@ export const testFor = test.extend({
   user,
   userPayloadWithRequiredProperties,
   userPayloadWithAllProperties,
+  voiceActor,
+  voiceActorCollection,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1,0 +1,106 @@
+import * as v from "valibot";
+import { type CollectionParameters, DatableString } from "../../src/base/v20170710";
+import { test } from "vitest";
+
+const emptyParams: CollectionParameters = {};
+
+const assignmentData = {
+  created_at: "2017-10-22T15:41:43.861883Z",
+  subject_id: 8761,
+  subject_type: "radical",
+  srs_stage: 9,
+  unlocked_at: "2021-07-22T21:03:22.905689Z",
+  started_at: "2021-07-30T15:11:42.594913Z",
+  passed_at: "2021-08-01T04:32:27.017606Z",
+  burned_at: "2022-01-20T20:03:37.269028Z",
+  available_at: null,
+  resurrected_at: null,
+  hidden: false,
+};
+
+const assignment = {
+  id: 85041695,
+  object: "assignment",
+  url: "https://api.wanikani.com/v2/assignments/85041695",
+  data_updated_at: "2025-01-22T18:06:08.895692Z",
+  data: assignmentData,
+};
+
+const assignmentCollection = {
+  object: "collection",
+  url: "https://api.wanikani.com/v2/assignments",
+  pages: {
+    per_page: 500,
+    next_url: "https://api.wanikani.com/v2/assignments?page_after_id=87485638",
+    previous_url: null,
+  },
+  total_count: 6055,
+  data_updated_at: "2025-02-15T22:19:50.167435Z",
+  data: [assignment],
+};
+
+const assignmentParamsWithEmptyArrays = {
+  ids: [],
+  levels: [],
+  srs_stages: [],
+  subject_ids: [],
+};
+
+const assignmentParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  page_after_id: 1,
+  page_before_id: 1,
+  burned: true,
+  hidden: false,
+  immediately_available_for_lessons: true,
+  immediately_available_for_review: false,
+  in_review: true,
+  levels: [1, 2, 3],
+  srs_stages: [1, 2, 3],
+  started: true,
+  subject_ids: [1, 2, 3],
+  subject_types: ["kana_vocabulary", "vocabulary"],
+  unlocked: true,
+};
+
+const assignmentParamsWithDates = {
+  available_after: new Date(),
+  available_before: new Date(),
+  updated_after: new Date(),
+};
+
+const assignmentParamsWithDatableStrings = {
+  available_after: v.parse(DatableString, new Date().toISOString()),
+  available_before: v.parse(DatableString, new Date().toISOString()),
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
+
+const assignmentPayloadWithNoTime = {
+  assignment: {},
+};
+
+const assignmentPayloadWithDate = {
+  assignment: {
+    started_at: new Date(),
+  },
+};
+
+const assignmentPayloadWithDatableString = {
+  assignment: {
+    started_at: v.parse(DatableString, "2024-12-27T15:32:23.000Z"),
+  },
+};
+
+export const testFor = test.extend({
+  emptyParams,
+  assignmentData,
+  assignment,
+  assignmentCollection,
+  assignmentParamsWithEmptyArrays,
+  assignmentParamsWithManyOptions,
+  assignmentParamsWithDates,
+  assignmentParamsWithDatableStrings,
+  assignmentPayloadWithNoTime,
+  assignmentPayloadWithDate,
+  assignmentPayloadWithDatableString,
+});

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1,13 +1,17 @@
 import * as v from "valibot";
-import { type CollectionParameters, DatableString } from "../../src/base/v20170710.js";
+import { type CollectionParameters, DatableString, SubjectTuple } from "../../src/base/v20170710.js";
 import { test } from "vitest";
 
+// Base
+
 const emptyParams: CollectionParameters = {};
+
+// Assignments
 
 const assignmentData = {
   created_at: v.parse(DatableString, "2017-10-22T15:41:43.861883Z"),
   subject_id: 8761,
-  subject_type: "radical",
+  subject_type: "radical" as const,
   srs_stage: 9,
   unlocked_at: v.parse(DatableString, "2021-07-22T21:03:22.905689Z"),
   started_at: v.parse(DatableString, "2021-07-30T15:11:42.594913Z"),
@@ -16,18 +20,18 @@ const assignmentData = {
   available_at: null,
   resurrected_at: null,
   hidden: false,
-} as const;
+};
 
 const assignment = {
   id: 85041695,
-  object: "assignment",
+  object: "assignment" as const,
   url: "https://api.wanikani.com/v2/assignments/85041695",
   data_updated_at: v.parse(DatableString, "2025-01-22T18:06:08.895692Z"),
   data: assignmentData,
 };
 
 const assignmentCollection = {
-  object: "collection",
+  object: "collection" as const,
   url: "https://api.wanikani.com/v2/assignments",
   pages: {
     per_page: 500,
@@ -59,7 +63,7 @@ const assignmentParamsWithManyOptions = {
   srs_stages: [1, 2, 3],
   started: true,
   subject_ids: [1, 2, 3],
-  subject_types: ["kana_vocabulary", "vocabulary"],
+  subject_types: v.parse(SubjectTuple, ["kana_vocabulary", "vocabulary"]),
   unlocked: true,
 };
 

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -6,6 +6,7 @@ import {
   MIN_LEVEL,
   SubjectTuple,
 } from "../../src/base/v20170710.js";
+import { MAX_SRS_STAGE, MIN_SRS_STAGE } from "../../src/spaced-repetition-systems/v20170710.js";
 import { ApiRequestFactory } from "../../src/requests/v20170710.js";
 import { test } from "vitest";
 
@@ -381,6 +382,95 @@ const reviewPayloadWithSubjectAndDatableStrings = {
     incorrect_meaning_answers: 0,
     incorrect_reading_answers: 0,
   },
+};
+
+// Spaced Repetition Systems
+
+const spacedRepetitionSystemStageNumbers = Array<number>(MAX_SRS_STAGE)
+  .fill(MIN_SRS_STAGE)
+  .map((stage, stageIdx) => stage + stageIdx);
+
+const spacedRepetitionSystemData = {
+  created_at: v.parse(DatableString, "2020-05-21T20:46:06.464460Z"),
+  name: "Default system for dictionary subjects",
+  description: "The original spaced repetition system",
+  unlocking_stage_position: 0,
+  starting_stage_position: 1,
+  passing_stage_position: 5,
+  burning_stage_position: 9,
+  stages: [
+    {
+      position: 0,
+      interval: null,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 1,
+      interval: 14400,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 2,
+      interval: 28800,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 3,
+      interval: 82800,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 4,
+      interval: 169200,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 5,
+      interval: 601200,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 6,
+      interval: 1206000,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 7,
+      interval: 2588400,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 8,
+      interval: 10364400,
+      interval_unit: "seconds" as const,
+    },
+    {
+      position: 9,
+      interval: null,
+      interval_unit: "seconds" as const,
+    },
+  ],
+};
+
+const spacedRepetitionSystem = {
+  id: 1,
+  object: "spaced_repetition_system" as const,
+  url: "https://api.wanikani.com/v2/spaced_repetition_systems/1",
+  data_updated_at: v.parse(DatableString, "2020-06-09T03:36:51.134752Z"),
+  data: spacedRepetitionSystemData,
+};
+
+const spacedRepetitionSystemCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/spaced_repetition_systems",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 2,
+  data_updated_at: v.parse(DatableString, "2020-06-09T03:38:01.007395Z"),
+  data: [spacedRepetitionSystem],
 };
 
 // Subjects
@@ -917,6 +1007,10 @@ export const testFor = test.extend({
   reviewPayloadWithAssignmentAndDatableStrings,
   reviewPayloadWithSubjectAndDate,
   reviewPayloadWithSubjectAndDatableStrings,
+  spacedRepetitionSystemStageNumbers,
+  spacedRepetitionSystemData,
+  spacedRepetitionSystem,
+  spacedRepetitionSystemCollection,
   radicalData,
   kanjiData,
   vocabularyData,

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -9,6 +9,7 @@ import {
 import { MAX_LESSON_BATCH_SIZE, MIN_LESSON_BATCH_SIZE } from "../../src/user/v20170710.js";
 import { MAX_SRS_STAGE, MIN_SRS_STAGE } from "../../src/spaced-repetition-systems/v20170710.js";
 import { ApiRequestFactory } from "../../src/requests/v20170710.js";
+import type { StudyMaterialUpdatePayload } from "../../src/v20170710.js";
 import { test } from "vitest";
 
 // Base
@@ -460,6 +461,78 @@ const spacedRepetitionSystemCollection = {
   total_count: 2,
   data_updated_at: v.parse(DatableString, "2020-06-09T03:38:01.007395Z"),
   data: [spacedRepetitionSystem],
+};
+
+// Study Materials
+
+const studyMaterial = {
+  id: 10089088,
+  object: "study_material" as const,
+  url: "https://api.wanikani.com/v2/study_materials/10089088",
+  data_updated_at: v.parse(DatableString, "2022-10-31T15:56:51.781056Z"),
+  data: {
+    created_at: v.parse(DatableString, "2022-10-31T15:49:19.637077Z"),
+    subject_id: 1,
+    subject_type: "radical" as const,
+    meaning_note: "It's one of a kind! Get it?",
+    reading_note: "",
+    meaning_synonyms: [],
+    hidden: false,
+  },
+};
+
+const studyMaterialCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/study_materials",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 3,
+  data_updated_at: v.parse(DatableString, "2025-01-16T17:05:46.992219Z"),
+  data: [studyMaterial],
+};
+
+const studyMaterialParamsWithEmptyArrays = {
+  ids: [],
+  subject_ids: [],
+};
+
+const studyMaterialParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  subject_ids: [1, 2, 3],
+  subject_types: v.parse(SubjectTuple, ["kana_vocabulary", "vocabulary"]),
+  hidden: false,
+  page_after_id: 1,
+  page_before_id: 1,
+};
+
+const studyMaterialParamsWithDates = {
+  updated_after: new Date(),
+};
+
+const studyMaterialParamsWithDatableStrings = {
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
+
+const emptyStudyMaterialUpdatePayload: StudyMaterialUpdatePayload = {};
+
+const fullStudyMaterialUpdatePayload = {
+  meaning_note: "Meaning note",
+  reading_note: "Reading Note",
+  meaning_synonyms: ["one", "two"],
+};
+
+const minimalStudyMaterialCreatePayload = {
+  subject_id: 1,
+};
+
+const fullStudyMaterialCreatePayload = {
+  subject_id: 1,
+  meaning_note: "Meaning note",
+  reading_note: "Reading Note",
+  meaning_synonyms: ["one", "two"],
 };
 
 // Subjects
@@ -1105,6 +1178,16 @@ export const testFor = test.extend({
   spacedRepetitionSystemStageNumbers,
   spacedRepetitionSystem,
   spacedRepetitionSystemCollection,
+  studyMaterial,
+  studyMaterialCollection,
+  studyMaterialParamsWithEmptyArrays,
+  studyMaterialParamsWithManyOptions,
+  studyMaterialParamsWithDates,
+  studyMaterialParamsWithDatableStrings,
+  emptyStudyMaterialUpdatePayload,
+  fullStudyMaterialUpdatePayload,
+  minimalStudyMaterialCreatePayload,
+  fullStudyMaterialCreatePayload,
   radical,
   kanji,
   vocabulary,

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -193,6 +193,36 @@ const levelProgressionCollection = {
 
 const requestFactory = new ApiRequestFactory({ apiToken: "abc", revision: "20170710" });
 
+// Resets
+
+const resetData = {
+  created_at: v.parse(DatableString, "2018-01-08T13:37:58.223692Z"),
+  original_level: 5,
+  target_level: 4,
+  confirmed_at: v.parse(DatableString, "2018-01-08T13:39:28.083543Z"),
+};
+
+const reset = {
+  id: 5006,
+  object: "reset" as const,
+  url: "https://api.wanikani.com/v2/resets/5006",
+  data_updated_at: v.parse(DatableString, "2018-01-08T13:39:38.304561Z"),
+  data: resetData,
+};
+
+const resetCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/resets",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 4,
+  data_updated_at: v.parse(DatableString, "2021-09-06T19:05:52.132672Z"),
+  data: [reset],
+};
+
 // Review Statistics
 
 const reviewStatisticData = {
@@ -287,6 +317,9 @@ export const testFor = test.extend({
   levelProgression,
   levelProgressionCollection,
   requestFactory,
+  resetData,
+  reset,
+  resetCollection,
   reviewStatisticData,
   reviewStatistic,
   reviewStatisticCollection,

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1,10 +1,70 @@
 import * as v from "valibot";
-import { type CollectionParameters, DatableString, SubjectTuple } from "../../src/base/v20170710.js";
+import {
+  type CollectionParameters,
+  DatableString,
+  MAX_LEVEL,
+  MIN_LEVEL,
+  SubjectTuple,
+} from "../../src/base/v20170710.js";
 import { test } from "vitest";
 
 // Base
 
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+const apiRevision = "20170710" as const;
+
+const dateTimeUtcString = "2022-10-23T15:17:38.828455Z";
+
+const dateTimeOffsetString = "2022-10-23T15:17:38.828455+09:00";
+
+const dateIsoString = new Date().toISOString();
+
+const levels = Array<number>(MAX_LEVEL)
+  .fill(MIN_LEVEL)
+  .map((item, itemIdx) => item + itemIdx);
+
+const resourceTypes = [
+  "assignment" as const,
+  "level_progression" as const,
+  "reset" as const,
+  "review_statistic" as const,
+  "review" as const,
+  "spaced_repetition_system" as const,
+  "study_material" as const,
+  "user" as const,
+  "voice_actor" as const,
+];
+
+const subjectTypes = ["kana_vocabulary" as const, "kanji" as const, "radical" as const, "vocabulary" as const];
+
+// @ts-expect-error -- Intentionally empty tuple needed a type and can't use unknown[] with vitest fixtures
+const emptySubjectTuple: SubjectTuple = [];
+
+const partialSubjectTuple: SubjectTuple = ["kanji"];
+
+const fullSubjectTuple: SubjectTuple = ["kana_vocabulary", "kanji", "radical", "vocabulary"];
+
+const repeatedSubjectTuple = ["kana_vocabulary", "kanji", "radical", "kanji", "vocabulary", "radical"];
+
 const emptyParams: CollectionParameters = {};
+
+const collectionParamsWithEmptyArrays = {
+  ids: [],
+};
+
+const collectionParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  page_after_id: 1,
+  page_before_id: 1,
+};
+
+const collectionParamsWithDates = {
+  updated_after: new Date(),
+};
+
+const collectionParamsWithDatableStrings = {
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
 
 // Assignments
 
@@ -96,7 +156,22 @@ const assignmentPayloadWithDatableString = {
 };
 
 export const testFor = test.extend({
+  apiRevision,
+  dateTimeUtcString,
+  dateTimeOffsetString,
+  dateIsoString,
+  levels,
+  resourceTypes,
+  subjectTypes,
+  emptySubjectTuple,
+  partialSubjectTuple,
+  fullSubjectTuple,
+  repeatedSubjectTuple,
   emptyParams,
+  collectionParamsWithEmptyArrays,
+  collectionParamsWithManyOptions,
+  collectionParamsWithDates,
+  collectionParamsWithDatableStrings,
   assignmentData,
   assignment,
   assignmentCollection,

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -286,6 +286,103 @@ const reviewStatisticParamsWithDatableStrings = {
   updated_after: v.parse(DatableString, new Date().toISOString()),
 };
 
+// Reviews
+
+/*
+ * N.b. The ReviewData, Review, and ReviewCollection fixtures are mock data; the Reviews endpoint is disabled as of
+ * writing.
+ */
+
+const reviewData = {
+  created_at: v.parse(DatableString, "2017-12-20T01:00:59.255427Z"),
+  assignment_id: 32132,
+  spaced_repetition_system_id: 1,
+  subject_id: 8,
+  starting_srs_stage: 4,
+  ending_srs_stage: 2,
+  incorrect_meaning_answers: 1,
+  incorrect_reading_answers: 0,
+};
+
+const review = {
+  id: 534342,
+  object: "review" as const,
+  url: "https://api.wanikani.com/v2/reviews/534342",
+  data_updated_at: v.parse(DatableString, "2017-12-20T01:00:59.255427Z"),
+  data: reviewData,
+};
+
+const reviewCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/reviews",
+  pages: {
+    per_page: 1000,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 1,
+  data_updated_at: v.parse(DatableString, "2017-12-20T01:10:17.578705Z"),
+  data: [review],
+};
+
+const reviewParamsWithEmptyArrays = {
+  ids: [],
+  assignment_ids: [],
+  subject_ids: [],
+};
+
+const reviewParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  assignment_ids: [1, 2, 3],
+  subject_ids: [1, 2, 3],
+  page_after_id: 1,
+  page_before_id: 1,
+};
+
+const reviewParamsWithDates = {
+  updated_after: new Date(),
+};
+
+const reviewParamsWithDatableStrings = {
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
+
+const reviewPayloadWithAssignmentAndDate = {
+  review: {
+    assignment_id: 1,
+    created_at: new Date(),
+    incorrect_meaning_answers: 0,
+    incorrect_reading_answers: 0,
+  },
+};
+
+const reviewPayloadWithAssignmentAndDatableStrings = {
+  review: {
+    assignment_id: 1,
+    created_at: v.parse(DatableString, new Date().toISOString()),
+    incorrect_meaning_answers: 0,
+    incorrect_reading_answers: 0,
+  },
+};
+
+const reviewPayloadWithSubjectAndDate = {
+  review: {
+    subject_id: 1,
+    created_at: new Date(),
+    incorrect_meaning_answers: 0,
+    incorrect_reading_answers: 0,
+  },
+};
+
+const reviewPayloadWithSubjectAndDatableStrings = {
+  review: {
+    subject_id: 1,
+    created_at: v.parse(DatableString, new Date().toISOString()),
+    incorrect_meaning_answers: 0,
+    incorrect_reading_answers: 0,
+  },
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -327,4 +424,15 @@ export const testFor = test.extend({
   reviewStatisticParamsWithManyOptions,
   reviewStatisticParamsWithDates,
   reviewStatisticParamsWithDatableStrings,
+  reviewData,
+  review,
+  reviewCollection,
+  reviewParamsWithEmptyArrays,
+  reviewParamsWithManyOptions,
+  reviewParamsWithDates,
+  reviewParamsWithDatableStrings,
+  reviewPayloadWithAssignmentAndDate,
+  reviewPayloadWithAssignmentAndDatableStrings,
+  reviewPayloadWithSubjectAndDate,
+  reviewPayloadWithSubjectAndDatableStrings,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -6,6 +6,7 @@ import {
   MIN_LEVEL,
   SubjectTuple,
 } from "../../src/base/v20170710.js";
+import { MAX_LESSON_BATCH_SIZE, MIN_LESSON_BATCH_SIZE } from "../../src/user/v20170710.js";
 import { MAX_SRS_STAGE, MIN_SRS_STAGE } from "../../src/spaced-repetition-systems/v20170710.js";
 import { ApiRequestFactory } from "../../src/requests/v20170710.js";
 import { test } from "vitest";
@@ -969,6 +970,63 @@ const summary = {
   },
 };
 
+// User
+
+const lessonBatchSizeNumbers = Array<number>(MAX_LESSON_BATCH_SIZE - 2)
+  .fill(MIN_LESSON_BATCH_SIZE)
+  .map((batchSize, batchSizeIdx) => batchSize + batchSizeIdx);
+
+const user = {
+  object: "user" as const,
+  url: "https://api.wanikani.com/v2/user",
+  data_updated_at: v.parse(DatableString, "2025-02-20T02:00:33.354445Z"),
+  data: {
+    id: "d5809441-e17f-4e57-acb0-6a232b714538",
+    username: "BachMac",
+    level: 37,
+    profile_url: "https://www.wanikani.com/users/BachMac",
+    started_at: v.parse(DatableString, "2017-10-22T15:41:43.815029Z"),
+    subscription: {
+      active: true,
+      type: "lifetime" as const,
+      max_level_granted: 60,
+      period_ends_at: null,
+    },
+    current_vacation_started_at: null,
+    preferences: {
+      lessons_autoplay_audio: false,
+      lessons_batch_size: 10,
+      reviews_autoplay_audio: false,
+      reviews_display_srs_indicator: true,
+      extra_study_autoplay_audio: false,
+      reviews_presentation_order: "lower_levels_first" as const,
+      lessons_presentation_order: "ascending_level_then_subject" as const,
+      default_voice_actor_id: 1,
+    },
+  },
+};
+
+const userPayloadWithRequiredProperties = {
+  user: {
+    preferences: {},
+  },
+};
+
+const userPayloadWithAllProperties = {
+  user: {
+    preferences: {
+      default_voice_actor_id: 1,
+      extra_study_autoplay_audio: false,
+      lessons_autoplay_audio: false,
+      lessons_batch_size: 10,
+      lessons_presentation_order: "ascending_level_then_subject" as const,
+      reviews_autoplay_audio: false,
+      reviews_display_srs_indicator: true,
+      reviews_presentation_order: "shuffled" as const,
+    },
+  },
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -1033,4 +1091,8 @@ export const testFor = test.extend({
   subjectParamsWithDates,
   subjectParamsWithDatableStrings,
   summary,
+  lessonBatchSizeNumbers,
+  user,
+  userPayloadWithRequiredProperties,
+  userPayloadWithAllProperties,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -383,6 +383,488 @@ const reviewPayloadWithSubjectAndDatableStrings = {
   },
 };
 
+// Subjects
+
+const radicalData = {
+  created_at: v.parse(DatableString, "2012-02-27T18:08:16.000000Z"),
+  level: 1,
+  slug: "ground",
+  hidden_at: null,
+  document_url: "https://www.wanikani.com/radicals/ground",
+  characters: "一",
+  character_images: [
+    {
+      url: "https://example.com",
+      metadata: {
+        inline_styles: true,
+      },
+      content_type: "image/svg+xml" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "1024x1024",
+        style_name: "original",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "1024x1024",
+        style_name: "1024px",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "512x512",
+        style_name: "512px",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "256x256",
+        style_name: "256px",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "128x128",
+        style_name: "128px",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "64x64",
+        style_name: "64px",
+      },
+      content_type: "image/png" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        color: "#000000",
+        dimensions: "32x32",
+        style_name: "32px",
+      },
+      content_type: "image/png" as const,
+    },
+  ],
+  meanings: [
+    {
+      meaning: "Ground",
+      primary: true,
+      accepted_answer: true,
+    },
+  ],
+  auxiliary_meanings: [],
+  amalgamation_subject_ids: [
+    440, 449, 450, 451, 468, 488, 531, 533, 568, 590, 609, 633, 635, 709, 710, 724, 783, 808, 885, 913, 932, 965, 971,
+    1000, 1020, 1085, 1119, 1126, 1137, 1178, 1198, 1241, 1249, 1310, 1326, 1340, 1367, 1372, 1376, 1379, 1428, 1431,
+    1463, 1491, 1521, 1547, 1559, 1591, 1655, 1769, 1851, 1852, 1855, 1868, 1869, 1888, 2085, 2104, 2128, 2138, 2148,
+    2171, 2172, 2182, 2212, 2277, 2334, 2375, 2419, 2437,
+  ],
+  meaning_mnemonic: "<snip>",
+  lesson_position: 0,
+  spaced_repetition_system_id: 2,
+};
+
+const kanjiData = {
+  created_at: v.parse(DatableString, "2012-02-27T19:55:19.000000Z"),
+  level: 1,
+  slug: "一",
+  hidden_at: null,
+  document_url: "https://www.wanikani.com/kanji/%E4%B8%80",
+  characters: "一",
+  meanings: [
+    {
+      meaning: "One",
+      primary: true,
+      accepted_answer: true,
+    },
+  ],
+  auxiliary_meanings: [
+    {
+      meaning: "1",
+      type: "whitelist" as const,
+    },
+  ],
+  readings: [
+    {
+      reading: "いち",
+      primary: true,
+      accepted_answer: true,
+      type: "onyomi" as const,
+    },
+    {
+      reading: "いつ",
+      primary: false,
+      accepted_answer: true,
+      type: "onyomi" as const,
+    },
+    {
+      reading: "ひと",
+      primary: false,
+      accepted_answer: false,
+      type: "kunyomi" as const,
+    },
+    {
+      reading: "かず",
+      primary: false,
+      accepted_answer: false,
+      type: "nanori" as const,
+    },
+  ],
+  component_subject_ids: [1],
+  amalgamation_subject_ids: [
+    2467, 2468, 2477, 2510, 2544, 2588, 2627, 2660, 2665, 2672, 2679, 2721, 2730, 2751, 2959, 3048, 3256, 3335, 3348,
+    3349, 3372, 3481, 3527, 3528, 3656, 3663, 4133, 4173, 4258, 4282, 4563, 4615, 4701, 4823, 4906, 5050, 5224, 5237,
+    5349, 5362, 5838, 6010, 6029, 6150, 6169, 6209, 6210, 6346, 6584, 6614, 6723, 6811, 6851, 7037, 7293, 7305, 7451,
+    7561, 7617, 7734, 7780, 7927, 8209, 8214, 8414, 8456, 8583, 8709, 8896, 8921, 9056, 9103, 9268, 9286, 9305, 9306,
+    9331,
+  ],
+  visually_similar_subject_ids: [],
+  meaning_mnemonic: "<snip>",
+  meaning_hint: "<snip>",
+  reading_mnemonic: "<snip>",
+  reading_hint: "<snip>",
+  lesson_position: 25,
+  spaced_repetition_system_id: 2,
+};
+
+const vocabularyData = {
+  created_at: v.parse(DatableString, "2012-02-28T08:04:47.000000Z"),
+  level: 1,
+  slug: "一",
+  hidden_at: null,
+  document_url: "https://www.wanikani.com/vocabulary/%E4%B8%80",
+  characters: "一",
+  meanings: [
+    {
+      meaning: "One",
+      primary: true,
+      accepted_answer: true,
+    },
+  ],
+  auxiliary_meanings: [
+    {
+      meaning: "1",
+      type: "whitelist" as const,
+    },
+  ],
+  readings: [
+    {
+      reading: "いち",
+      primary: true,
+      accepted_answer: true,
+    },
+  ],
+  parts_of_speech: ["numeral"],
+  component_subject_ids: [440],
+  meaning_mnemonic: "<snip>",
+  reading_mnemonic: "<snip>",
+  context_sentences: [
+    {
+      en: "<snip>",
+      ja: "<snip>",
+    },
+  ],
+  pronunciation_audios: [
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "male" as const,
+        source_id: 2711,
+        pronunciation: "いち",
+        voice_actor_id: 2,
+        voice_actor_name: "Kenichi",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/webm" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "female" as const,
+        source_id: 21630,
+        pronunciation: "いち",
+        voice_actor_id: 1,
+        voice_actor_name: "Kyoko",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/webm" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "female" as const,
+        source_id: 21630,
+        pronunciation: "いち",
+        voice_actor_id: 1,
+        voice_actor_name: "Kyoko",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/mpeg" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "male" as const,
+        source_id: 2711,
+        pronunciation: "いち",
+        voice_actor_id: 2,
+        voice_actor_name: "Kenichi",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/mpeg" as const,
+    },
+  ],
+  lesson_position: 43,
+  spaced_repetition_system_id: 2,
+};
+
+const kanaVocabularyData = {
+  created_at: v.parse(DatableString, "2022-09-14T11:39:10.684981Z"),
+  level: 10,
+  slug: "ちょっと",
+  hidden_at: null,
+  document_url: "https://www.wanikani.com/vocabulary/%E3%81%A1%E3%82%87%E3%81%A3%E3%81%A8",
+  characters: "ちょっと",
+  meanings: [
+    {
+      meaning: "A Little",
+      primary: true,
+      accepted_answer: true,
+    },
+    {
+      meaning: "A Moment",
+      primary: false,
+      accepted_answer: true,
+    },
+  ],
+  auxiliary_meanings: [
+    {
+      meaning: "A Bit",
+      type: "whitelist" as const,
+    },
+    {
+      meaning: "A Few",
+      type: "whitelist" as const,
+    },
+    {
+      meaning: "For A Moment",
+      type: "whitelist" as const,
+    },
+    {
+      meaning: "A Minute",
+      type: "whitelist" as const,
+    },
+    {
+      meaning: "For A Minute",
+      type: "whitelist" as const,
+    },
+    {
+      meaning: "Some",
+      type: "whitelist" as const,
+    },
+  ],
+  parts_of_speech: ["adverb"],
+  meaning_mnemonic: "<snip>",
+  context_sentences: [
+    {
+      en: "<snip>",
+      ja: "<snip>",
+    },
+  ],
+  pronunciation_audios: [
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "female" as const,
+        source_id: 44712,
+        pronunciation: "ちょっと",
+        voice_actor_id: 1,
+        voice_actor_name: "Kyoko",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/webm" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "female" as const,
+        source_id: 44712,
+        pronunciation: "ちょっと",
+        voice_actor_id: 1,
+        voice_actor_name: "Kyoko",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/mpeg" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "male" as const,
+        source_id: 44771,
+        pronunciation: "ちょっと",
+        voice_actor_id: 2,
+        voice_actor_name: "Kenichi",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/webm" as const,
+    },
+    {
+      url: "https://example.com",
+      metadata: {
+        gender: "male" as const,
+        source_id: 44771,
+        pronunciation: "ちょっと",
+        voice_actor_id: 2,
+        voice_actor_name: "Kenichi",
+        voice_description: "Tokyo accent",
+      },
+      content_type: "audio/mpeg" as const,
+    },
+  ],
+  lesson_position: 59,
+  spaced_repetition_system_id: 1,
+};
+
+const radical = {
+  id: 1,
+  object: "radical" as const,
+  url: "https://api.wanikani.com/v2/subjects/1",
+  data_updated_at: v.parse(DatableString, "2025-01-16T17:11:09.063973Z"),
+  data: radicalData,
+};
+
+const kanji = {
+  id: 440,
+  object: "kanji" as const,
+  url: "https://api.wanikani.com/v2/subjects/440",
+  data_updated_at: v.parse(DatableString, "2025-01-21T15:25:03.362576Z"),
+  data: kanjiData,
+};
+
+const vocabulary = {
+  id: 2467,
+  object: "vocabulary" as const,
+  url: "https://api.wanikani.com/v2/subjects/2467",
+  data_updated_at: v.parse(DatableString, "2024-10-15T22:13:34.087679Z"),
+  data: vocabularyData,
+};
+
+const kanaVocabulary = {
+  id: 9176,
+  object: "kana_vocabulary" as const,
+  url: "https://api.wanikani.com/v2/subjects/9176",
+  data_updated_at: v.parse(DatableString, "2024-10-15T22:19:11.286457Z"),
+  data: kanaVocabularyData,
+};
+
+const radicalCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/subjects?types=radical",
+  pages: {
+    per_page: 1000,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 499,
+  data_updated_at: v.parse(DatableString, "2025-02-21T20:51:23.378189Z"),
+  data: [radical],
+};
+
+const kanjiCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/subjects?types=kanji",
+  pages: {
+    per_page: 1000,
+    next_url: "https://api.wanikani.com/v2/subjects?page_after_id=1439&types=kanji",
+    previous_url: null,
+  },
+  total_count: 2080,
+  data_updated_at: v.parse(DatableString, "2025-02-23T04:24:12.403083Z"),
+  data: [kanji],
+};
+
+const vocabularyCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/subjects?types=vocabulary",
+  pages: {
+    per_page: 1000,
+    next_url: "https://api.wanikani.com/v2/subjects?page_after_id=3468&types=vocabulary",
+    previous_url: null,
+  },
+  total_count: 6630,
+  data_updated_at: v.parse(DatableString, "2025-02-23T04:24:12.372546Z"),
+  data: [vocabulary],
+};
+
+const kanaVocabularyCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/subjects?types=kana_vocabulary",
+  pages: {
+    per_page: 1000,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 60,
+  data_updated_at: v.parse(DatableString, "2025-01-31T00:42:02.755193Z"),
+  data: [kanaVocabulary],
+};
+
+const subjectCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/subjects",
+  pages: {
+    per_page: 1000,
+    next_url: "https://api.wanikani.com/v2/subjects?page_after_id=1000",
+    previous_url: null,
+  },
+  total_count: 9269,
+  data_updated_at: v.parse(DatableString, "2025-02-23T04:24:12.403083Z"),
+  data: [radical, kanji, vocabulary, kanaVocabulary],
+};
+
+const subjectParamsWithEmptyArrays = {
+  ids: [],
+  levels: [],
+  slugs: [],
+};
+
+const subjectParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  levels: [1, 2, 3],
+  slugs: ["one", "two", "three"],
+  types: v.parse(SubjectTuple, ["radical", "kanji"]),
+  hidden: false,
+  page_after_id: 1,
+  page_before_id: 1,
+};
+
+const subjectParamsWithDates = {
+  updated_after: new Date(),
+};
+
+const subjectParamsWithDatableStrings = {
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -435,4 +917,21 @@ export const testFor = test.extend({
   reviewPayloadWithAssignmentAndDatableStrings,
   reviewPayloadWithSubjectAndDate,
   reviewPayloadWithSubjectAndDatableStrings,
+  radicalData,
+  kanjiData,
+  vocabularyData,
+  kanaVocabularyData,
+  radical,
+  kanji,
+  vocabulary,
+  kanaVocabulary,
+  radicalCollection,
+  kanjiCollection,
+  vocabularyCollection,
+  kanaVocabularyCollection,
+  subjectCollection,
+  subjectParamsWithEmptyArrays,
+  subjectParamsWithManyOptions,
+  subjectParamsWithDates,
+  subjectParamsWithDatableStrings,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -6,6 +6,7 @@ import {
   MIN_LEVEL,
   SubjectTuple,
 } from "../../src/base/v20170710.js";
+import { ApiRequestFactory } from "../../src/requests/v20170710.js";
 import { test } from "vitest";
 
 // Base
@@ -188,6 +189,10 @@ const levelProgressionCollection = {
   data: [levelProgression],
 };
 
+// Requests
+
+const requestFactory = new ApiRequestFactory({ apiToken: "abc", revision: "20170710" });
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -218,4 +223,5 @@ export const testFor = test.extend({
   levelProgressionData,
   levelProgression,
   levelProgressionCollection,
+  requestFactory,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -193,6 +193,69 @@ const levelProgressionCollection = {
 
 const requestFactory = new ApiRequestFactory({ apiToken: "abc", revision: "20170710" });
 
+// Review Statistics
+
+const reviewStatisticData = {
+  created_at: v.parse(DatableString, "2017-10-22T15:41:43.876100Z"),
+  subject_id: 8761,
+  subject_type: "radical" as const,
+  meaning_correct: 8,
+  meaning_incorrect: 0,
+  meaning_max_streak: 8,
+  meaning_current_streak: 8,
+  reading_correct: 8,
+  reading_incorrect: 0,
+  reading_max_streak: 8,
+  reading_current_streak: 8,
+  percentage_correct: 100,
+  hidden: false,
+};
+
+const reviewStatistic = {
+  id: 85040524,
+  object: "review_statistic" as const,
+  url: "https://api.wanikani.com/v2/review_statistics/85040524",
+  data_updated_at: v.parse(DatableString, "2025-01-22T18:06:07.048082Z"),
+  data: reviewStatisticData,
+};
+
+const reviewStatisticCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/review_statistics",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 5984,
+  data_updated_at: v.parse(DatableString, "2025-01-22T18:06:07.048082Z"),
+  data: [reviewStatistic],
+};
+
+const reviewStatisticParamsWithEmptyArrays = {
+  ids: [],
+  subject_ids: [],
+};
+
+const reviewStatisticParamsWithManyOptions = {
+  ids: [1, 2, 3],
+  page_after_id: 1,
+  page_before_id: 1,
+  hidden: false,
+  percentages_greater_than: 90,
+  percentages_less_than: 100,
+  subject_ids: [1, 2, 3],
+  subject_types: v.parse(SubjectTuple, ["kana_vocabulary", "vocabulary"]),
+};
+
+const reviewStatisticParamsWithDates = {
+  updated_after: new Date(),
+};
+
+const reviewStatisticParamsWithDatableStrings = {
+  updated_after: v.parse(DatableString, new Date().toISOString()),
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -224,4 +287,11 @@ export const testFor = test.extend({
   levelProgression,
   levelProgressionCollection,
   requestFactory,
+  reviewStatisticData,
+  reviewStatistic,
+  reviewStatisticCollection,
+  reviewStatisticParamsWithEmptyArrays,
+  reviewStatisticParamsWithManyOptions,
+  reviewStatisticParamsWithDates,
+  reviewStatisticParamsWithDatableStrings,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -955,6 +955,40 @@ const subjectParamsWithDatableStrings = {
   updated_after: v.parse(DatableString, new Date().toISOString()),
 };
 
+// Summary
+
+const summary = {
+  object: "report" as const,
+  url: "https://api.wanikani.com/v2/summary",
+  data_updated_at: v.parse(DatableString, "2025-02-23T11:00:00.000000Z"),
+  data: {
+    lessons: [
+      {
+        available_at: v.parse(DatableString, "2025-02-23T11:00:00.000000Z"),
+        subject_ids: [
+          1672, 5998, 5999, 5971, 5972, 5973, 6001, 6002, 5970, 5992, 5993, 5994, 9266, 6003, 6004, 6010, 5986, 5987,
+          5988, 6027, 5980, 5981, 6005, 6006, 6007, 6008, 7663, 5963, 5964, 5965, 364, 1657, 1664, 6048, 1665, 6047,
+          366, 1647, 365, 1670, 6040, 6581, 1645, 1649, 8862, 6034, 6041, 6029, 8556, 6031, 6038, 6042, 6033, 1667,
+          6039, 1644, 1653, 1654, 1660, 1662, 1673, 6036, 1659, 1651, 1663, 1648, 1668, 1674, 6032, 6035, 6043, 6045,
+          6080, 6049, 6044, 363, 395, 6046, 1655, 1661, 1650, 5966, 5967, 5968, 5969, 5956, 5957, 5958, 6037, 5996,
+          5997, 2384, 1669, 1656,
+        ],
+      },
+    ],
+    next_reviews_at: v.parse(DatableString, "2025-02-23T12:00:00.000000Z"),
+    reviews: [
+      {
+        available_at: v.parse(DatableString, "2025-02-23T11:00:00.000000Z"),
+        subject_ids: [],
+      },
+      {
+        available_at: v.parse(DatableString, "2025-02-23T12:00:00.000000Z"),
+        subject_ids: [6026, 5959, 5961, 5989, 5979, 5990, 7609, 5960, 5962, 5991],
+      },
+    ],
+  },
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -1028,4 +1062,5 @@ export const testFor = test.extend({
   subjectParamsWithManyOptions,
   subjectParamsWithDates,
   subjectParamsWithDatableStrings,
+  summary,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -155,6 +155,39 @@ const assignmentPayloadWithDatableString = {
   },
 };
 
+// Level Progressions
+
+const levelProgressionData = {
+  created_at: v.parse(DatableString, "2017-10-22T15:41:43.832193Z"),
+  level: 1,
+  unlocked_at: v.parse(DatableString, "2017-10-22T15:41:43.830826Z"),
+  started_at: v.parse(DatableString, "2017-10-22T16:01:12.321365Z"),
+  passed_at: v.parse(DatableString, "2017-10-31T11:18:33.026476Z"),
+  completed_at: null,
+  abandoned_at: null,
+};
+
+const levelProgression = {
+  id: 188765,
+  object: "level_progression" as const,
+  url: "https://api.wanikani.com/v2/level_progressions/188765",
+  data_updated_at: v.parse(DatableString, "2017-10-31T11:18:33.036424Z"),
+  data: levelProgressionData,
+};
+
+const levelProgressionCollection = {
+  object: "collection" as const,
+  url: "https://api.wanikani.com/v2/level_progressions",
+  pages: {
+    per_page: 500,
+    next_url: null,
+    previous_url: null,
+  },
+  total_count: 50,
+  data_updated_at: v.parse(DatableString, "2025-02-20T02:00:33.397409Z"),
+  data: [levelProgression],
+};
+
 export const testFor = test.extend({
   apiRevision,
   dateTimeUtcString,
@@ -182,4 +215,7 @@ export const testFor = test.extend({
   assignmentPayloadWithNoTime,
   assignmentPayloadWithDate,
   assignmentPayloadWithDatableString,
+  levelProgressionData,
+  levelProgression,
+  levelProgressionCollection,
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -70,26 +70,24 @@ const collectionParamsWithDatableStrings = {
 
 // Assignments
 
-const assignmentData = {
-  created_at: v.parse(DatableString, "2017-10-22T15:41:43.861883Z"),
-  subject_id: 8761,
-  subject_type: "radical" as const,
-  srs_stage: 9,
-  unlocked_at: v.parse(DatableString, "2021-07-22T21:03:22.905689Z"),
-  started_at: v.parse(DatableString, "2021-07-30T15:11:42.594913Z"),
-  passed_at: v.parse(DatableString, "2021-08-01T04:32:27.017606Z"),
-  burned_at: v.parse(DatableString, "2022-01-20T20:03:37.269028Z"),
-  available_at: null,
-  resurrected_at: null,
-  hidden: false,
-};
-
 const assignment = {
   id: 85041695,
   object: "assignment" as const,
   url: "https://api.wanikani.com/v2/assignments/85041695",
   data_updated_at: v.parse(DatableString, "2025-01-22T18:06:08.895692Z"),
-  data: assignmentData,
+  data: {
+    created_at: v.parse(DatableString, "2017-10-22T15:41:43.861883Z"),
+    subject_id: 8761,
+    subject_type: "radical" as const,
+    srs_stage: 9,
+    unlocked_at: v.parse(DatableString, "2021-07-22T21:03:22.905689Z"),
+    started_at: v.parse(DatableString, "2021-07-30T15:11:42.594913Z"),
+    passed_at: v.parse(DatableString, "2021-08-01T04:32:27.017606Z"),
+    burned_at: v.parse(DatableString, "2022-01-20T20:03:37.269028Z"),
+    available_at: null,
+    resurrected_at: null,
+    hidden: false,
+  },
 };
 
 const assignmentCollection = {
@@ -159,22 +157,20 @@ const assignmentPayloadWithDatableString = {
 
 // Level Progressions
 
-const levelProgressionData = {
-  created_at: v.parse(DatableString, "2017-10-22T15:41:43.832193Z"),
-  level: 1,
-  unlocked_at: v.parse(DatableString, "2017-10-22T15:41:43.830826Z"),
-  started_at: v.parse(DatableString, "2017-10-22T16:01:12.321365Z"),
-  passed_at: v.parse(DatableString, "2017-10-31T11:18:33.026476Z"),
-  completed_at: null,
-  abandoned_at: null,
-};
-
 const levelProgression = {
   id: 188765,
   object: "level_progression" as const,
   url: "https://api.wanikani.com/v2/level_progressions/188765",
   data_updated_at: v.parse(DatableString, "2017-10-31T11:18:33.036424Z"),
-  data: levelProgressionData,
+  data: {
+    created_at: v.parse(DatableString, "2017-10-22T15:41:43.832193Z"),
+    level: 1,
+    unlocked_at: v.parse(DatableString, "2017-10-22T15:41:43.830826Z"),
+    started_at: v.parse(DatableString, "2017-10-22T16:01:12.321365Z"),
+    passed_at: v.parse(DatableString, "2017-10-31T11:18:33.026476Z"),
+    completed_at: null,
+    abandoned_at: null,
+  },
 };
 
 const levelProgressionCollection = {
@@ -196,19 +192,17 @@ const requestFactory = new ApiRequestFactory({ apiToken: "abc", revision: "20170
 
 // Resets
 
-const resetData = {
-  created_at: v.parse(DatableString, "2018-01-08T13:37:58.223692Z"),
-  original_level: 5,
-  target_level: 4,
-  confirmed_at: v.parse(DatableString, "2018-01-08T13:39:28.083543Z"),
-};
-
 const reset = {
   id: 5006,
   object: "reset" as const,
   url: "https://api.wanikani.com/v2/resets/5006",
   data_updated_at: v.parse(DatableString, "2018-01-08T13:39:38.304561Z"),
-  data: resetData,
+  data: {
+    created_at: v.parse(DatableString, "2018-01-08T13:37:58.223692Z"),
+    original_level: 5,
+    target_level: 4,
+    confirmed_at: v.parse(DatableString, "2018-01-08T13:39:28.083543Z"),
+  },
 };
 
 const resetCollection = {
@@ -226,28 +220,26 @@ const resetCollection = {
 
 // Review Statistics
 
-const reviewStatisticData = {
-  created_at: v.parse(DatableString, "2017-10-22T15:41:43.876100Z"),
-  subject_id: 8761,
-  subject_type: "radical" as const,
-  meaning_correct: 8,
-  meaning_incorrect: 0,
-  meaning_max_streak: 8,
-  meaning_current_streak: 8,
-  reading_correct: 8,
-  reading_incorrect: 0,
-  reading_max_streak: 8,
-  reading_current_streak: 8,
-  percentage_correct: 100,
-  hidden: false,
-};
-
 const reviewStatistic = {
   id: 85040524,
   object: "review_statistic" as const,
   url: "https://api.wanikani.com/v2/review_statistics/85040524",
   data_updated_at: v.parse(DatableString, "2025-01-22T18:06:07.048082Z"),
-  data: reviewStatisticData,
+  data: {
+    created_at: v.parse(DatableString, "2017-10-22T15:41:43.876100Z"),
+    subject_id: 8761,
+    subject_type: "radical" as const,
+    meaning_correct: 8,
+    meaning_incorrect: 0,
+    meaning_max_streak: 8,
+    meaning_current_streak: 8,
+    reading_correct: 8,
+    reading_incorrect: 0,
+    reading_max_streak: 8,
+    reading_current_streak: 8,
+    percentage_correct: 100,
+    hidden: false,
+  },
 };
 
 const reviewStatisticCollection = {
@@ -290,27 +282,25 @@ const reviewStatisticParamsWithDatableStrings = {
 // Reviews
 
 /*
- * N.b. The ReviewData, Review, and ReviewCollection fixtures are mock data; the Reviews endpoint is disabled as of
+ * N.b. The Review and ReviewCollection fixtures are mock data; the Reviews endpoint is disabled as of
  * writing.
  */
-
-const reviewData = {
-  created_at: v.parse(DatableString, "2017-12-20T01:00:59.255427Z"),
-  assignment_id: 32132,
-  spaced_repetition_system_id: 1,
-  subject_id: 8,
-  starting_srs_stage: 4,
-  ending_srs_stage: 2,
-  incorrect_meaning_answers: 1,
-  incorrect_reading_answers: 0,
-};
 
 const review = {
   id: 534342,
   object: "review" as const,
   url: "https://api.wanikani.com/v2/reviews/534342",
   data_updated_at: v.parse(DatableString, "2017-12-20T01:00:59.255427Z"),
-  data: reviewData,
+  data: {
+    created_at: v.parse(DatableString, "2017-12-20T01:00:59.255427Z"),
+    assignment_id: 32132,
+    spaced_repetition_system_id: 1,
+    subject_id: 8,
+    starting_srs_stage: 4,
+    ending_srs_stage: 2,
+    incorrect_meaning_answers: 1,
+    incorrect_reading_answers: 0,
+  },
 };
 
 const reviewCollection = {
@@ -390,74 +380,72 @@ const spacedRepetitionSystemStageNumbers = Array<number>(MAX_SRS_STAGE)
   .fill(MIN_SRS_STAGE)
   .map((stage, stageIdx) => stage + stageIdx);
 
-const spacedRepetitionSystemData = {
-  created_at: v.parse(DatableString, "2020-05-21T20:46:06.464460Z"),
-  name: "Default system for dictionary subjects",
-  description: "The original spaced repetition system",
-  unlocking_stage_position: 0,
-  starting_stage_position: 1,
-  passing_stage_position: 5,
-  burning_stage_position: 9,
-  stages: [
-    {
-      position: 0,
-      interval: null,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 1,
-      interval: 14400,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 2,
-      interval: 28800,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 3,
-      interval: 82800,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 4,
-      interval: 169200,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 5,
-      interval: 601200,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 6,
-      interval: 1206000,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 7,
-      interval: 2588400,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 8,
-      interval: 10364400,
-      interval_unit: "seconds" as const,
-    },
-    {
-      position: 9,
-      interval: null,
-      interval_unit: "seconds" as const,
-    },
-  ],
-};
-
 const spacedRepetitionSystem = {
   id: 1,
   object: "spaced_repetition_system" as const,
   url: "https://api.wanikani.com/v2/spaced_repetition_systems/1",
   data_updated_at: v.parse(DatableString, "2020-06-09T03:36:51.134752Z"),
-  data: spacedRepetitionSystemData,
+  data: {
+    created_at: v.parse(DatableString, "2020-05-21T20:46:06.464460Z"),
+    name: "Default system for dictionary subjects",
+    description: "The original spaced repetition system",
+    unlocking_stage_position: 0,
+    starting_stage_position: 1,
+    passing_stage_position: 5,
+    burning_stage_position: 9,
+    stages: [
+      {
+        position: 0,
+        interval: null,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 1,
+        interval: 14400,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 2,
+        interval: 28800,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 3,
+        interval: 82800,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 4,
+        interval: 169200,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 5,
+        interval: 601200,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 6,
+        interval: 1206000,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 7,
+        interval: 2588400,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 8,
+        interval: 10364400,
+        interval_unit: "seconds" as const,
+      },
+      {
+        position: 9,
+        interval: null,
+        interval_unit: "seconds" as const,
+      },
+    ],
+  },
 };
 
 const spacedRepetitionSystemCollection = {
@@ -475,371 +463,108 @@ const spacedRepetitionSystemCollection = {
 
 // Subjects
 
-const radicalData = {
-  created_at: v.parse(DatableString, "2012-02-27T18:08:16.000000Z"),
-  level: 1,
-  slug: "ground",
-  hidden_at: null,
-  document_url: "https://www.wanikani.com/radicals/ground",
-  characters: "一",
-  character_images: [
-    {
-      url: "https://example.com",
-      metadata: {
-        inline_styles: true,
-      },
-      content_type: "image/svg+xml" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "1024x1024",
-        style_name: "original",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "1024x1024",
-        style_name: "1024px",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "512x512",
-        style_name: "512px",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "256x256",
-        style_name: "256px",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "128x128",
-        style_name: "128px",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "64x64",
-        style_name: "64px",
-      },
-      content_type: "image/png" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        color: "#000000",
-        dimensions: "32x32",
-        style_name: "32px",
-      },
-      content_type: "image/png" as const,
-    },
-  ],
-  meanings: [
-    {
-      meaning: "Ground",
-      primary: true,
-      accepted_answer: true,
-    },
-  ],
-  auxiliary_meanings: [],
-  amalgamation_subject_ids: [
-    440, 449, 450, 451, 468, 488, 531, 533, 568, 590, 609, 633, 635, 709, 710, 724, 783, 808, 885, 913, 932, 965, 971,
-    1000, 1020, 1085, 1119, 1126, 1137, 1178, 1198, 1241, 1249, 1310, 1326, 1340, 1367, 1372, 1376, 1379, 1428, 1431,
-    1463, 1491, 1521, 1547, 1559, 1591, 1655, 1769, 1851, 1852, 1855, 1868, 1869, 1888, 2085, 2104, 2128, 2138, 2148,
-    2171, 2172, 2182, 2212, 2277, 2334, 2375, 2419, 2437,
-  ],
-  meaning_mnemonic: "<snip>",
-  lesson_position: 0,
-  spaced_repetition_system_id: 2,
-};
-
-const kanjiData = {
-  created_at: v.parse(DatableString, "2012-02-27T19:55:19.000000Z"),
-  level: 1,
-  slug: "一",
-  hidden_at: null,
-  document_url: "https://www.wanikani.com/kanji/%E4%B8%80",
-  characters: "一",
-  meanings: [
-    {
-      meaning: "One",
-      primary: true,
-      accepted_answer: true,
-    },
-  ],
-  auxiliary_meanings: [
-    {
-      meaning: "1",
-      type: "whitelist" as const,
-    },
-  ],
-  readings: [
-    {
-      reading: "いち",
-      primary: true,
-      accepted_answer: true,
-      type: "onyomi" as const,
-    },
-    {
-      reading: "いつ",
-      primary: false,
-      accepted_answer: true,
-      type: "onyomi" as const,
-    },
-    {
-      reading: "ひと",
-      primary: false,
-      accepted_answer: false,
-      type: "kunyomi" as const,
-    },
-    {
-      reading: "かず",
-      primary: false,
-      accepted_answer: false,
-      type: "nanori" as const,
-    },
-  ],
-  component_subject_ids: [1],
-  amalgamation_subject_ids: [
-    2467, 2468, 2477, 2510, 2544, 2588, 2627, 2660, 2665, 2672, 2679, 2721, 2730, 2751, 2959, 3048, 3256, 3335, 3348,
-    3349, 3372, 3481, 3527, 3528, 3656, 3663, 4133, 4173, 4258, 4282, 4563, 4615, 4701, 4823, 4906, 5050, 5224, 5237,
-    5349, 5362, 5838, 6010, 6029, 6150, 6169, 6209, 6210, 6346, 6584, 6614, 6723, 6811, 6851, 7037, 7293, 7305, 7451,
-    7561, 7617, 7734, 7780, 7927, 8209, 8214, 8414, 8456, 8583, 8709, 8896, 8921, 9056, 9103, 9268, 9286, 9305, 9306,
-    9331,
-  ],
-  visually_similar_subject_ids: [],
-  meaning_mnemonic: "<snip>",
-  meaning_hint: "<snip>",
-  reading_mnemonic: "<snip>",
-  reading_hint: "<snip>",
-  lesson_position: 25,
-  spaced_repetition_system_id: 2,
-};
-
-const vocabularyData = {
-  created_at: v.parse(DatableString, "2012-02-28T08:04:47.000000Z"),
-  level: 1,
-  slug: "一",
-  hidden_at: null,
-  document_url: "https://www.wanikani.com/vocabulary/%E4%B8%80",
-  characters: "一",
-  meanings: [
-    {
-      meaning: "One",
-      primary: true,
-      accepted_answer: true,
-    },
-  ],
-  auxiliary_meanings: [
-    {
-      meaning: "1",
-      type: "whitelist" as const,
-    },
-  ],
-  readings: [
-    {
-      reading: "いち",
-      primary: true,
-      accepted_answer: true,
-    },
-  ],
-  parts_of_speech: ["numeral"],
-  component_subject_ids: [440],
-  meaning_mnemonic: "<snip>",
-  reading_mnemonic: "<snip>",
-  context_sentences: [
-    {
-      en: "<snip>",
-      ja: "<snip>",
-    },
-  ],
-  pronunciation_audios: [
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "male" as const,
-        source_id: 2711,
-        pronunciation: "いち",
-        voice_actor_id: 2,
-        voice_actor_name: "Kenichi",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/webm" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "female" as const,
-        source_id: 21630,
-        pronunciation: "いち",
-        voice_actor_id: 1,
-        voice_actor_name: "Kyoko",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/webm" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "female" as const,
-        source_id: 21630,
-        pronunciation: "いち",
-        voice_actor_id: 1,
-        voice_actor_name: "Kyoko",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/mpeg" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "male" as const,
-        source_id: 2711,
-        pronunciation: "いち",
-        voice_actor_id: 2,
-        voice_actor_name: "Kenichi",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/mpeg" as const,
-    },
-  ],
-  lesson_position: 43,
-  spaced_repetition_system_id: 2,
-};
-
-const kanaVocabularyData = {
-  created_at: v.parse(DatableString, "2022-09-14T11:39:10.684981Z"),
-  level: 10,
-  slug: "ちょっと",
-  hidden_at: null,
-  document_url: "https://www.wanikani.com/vocabulary/%E3%81%A1%E3%82%87%E3%81%A3%E3%81%A8",
-  characters: "ちょっと",
-  meanings: [
-    {
-      meaning: "A Little",
-      primary: true,
-      accepted_answer: true,
-    },
-    {
-      meaning: "A Moment",
-      primary: false,
-      accepted_answer: true,
-    },
-  ],
-  auxiliary_meanings: [
-    {
-      meaning: "A Bit",
-      type: "whitelist" as const,
-    },
-    {
-      meaning: "A Few",
-      type: "whitelist" as const,
-    },
-    {
-      meaning: "For A Moment",
-      type: "whitelist" as const,
-    },
-    {
-      meaning: "A Minute",
-      type: "whitelist" as const,
-    },
-    {
-      meaning: "For A Minute",
-      type: "whitelist" as const,
-    },
-    {
-      meaning: "Some",
-      type: "whitelist" as const,
-    },
-  ],
-  parts_of_speech: ["adverb"],
-  meaning_mnemonic: "<snip>",
-  context_sentences: [
-    {
-      en: "<snip>",
-      ja: "<snip>",
-    },
-  ],
-  pronunciation_audios: [
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "female" as const,
-        source_id: 44712,
-        pronunciation: "ちょっと",
-        voice_actor_id: 1,
-        voice_actor_name: "Kyoko",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/webm" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "female" as const,
-        source_id: 44712,
-        pronunciation: "ちょっと",
-        voice_actor_id: 1,
-        voice_actor_name: "Kyoko",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/mpeg" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "male" as const,
-        source_id: 44771,
-        pronunciation: "ちょっと",
-        voice_actor_id: 2,
-        voice_actor_name: "Kenichi",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/webm" as const,
-    },
-    {
-      url: "https://example.com",
-      metadata: {
-        gender: "male" as const,
-        source_id: 44771,
-        pronunciation: "ちょっと",
-        voice_actor_id: 2,
-        voice_actor_name: "Kenichi",
-        voice_description: "Tokyo accent",
-      },
-      content_type: "audio/mpeg" as const,
-    },
-  ],
-  lesson_position: 59,
-  spaced_repetition_system_id: 1,
-};
-
 const radical = {
   id: 1,
   object: "radical" as const,
   url: "https://api.wanikani.com/v2/subjects/1",
   data_updated_at: v.parse(DatableString, "2025-01-16T17:11:09.063973Z"),
-  data: radicalData,
+  data: {
+    created_at: v.parse(DatableString, "2012-02-27T18:08:16.000000Z"),
+    level: 1,
+    slug: "ground",
+    hidden_at: null,
+    document_url: "https://www.wanikani.com/radicals/ground",
+    characters: "一",
+    character_images: [
+      {
+        url: "https://example.com",
+        metadata: {
+          inline_styles: true,
+        },
+        content_type: "image/svg+xml" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "1024x1024",
+          style_name: "original",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "1024x1024",
+          style_name: "1024px",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "512x512",
+          style_name: "512px",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "256x256",
+          style_name: "256px",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "128x128",
+          style_name: "128px",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "64x64",
+          style_name: "64px",
+        },
+        content_type: "image/png" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          color: "#000000",
+          dimensions: "32x32",
+          style_name: "32px",
+        },
+        content_type: "image/png" as const,
+      },
+    ],
+    meanings: [
+      {
+        meaning: "Ground",
+        primary: true,
+        accepted_answer: true,
+      },
+    ],
+    auxiliary_meanings: [],
+    amalgamation_subject_ids: [
+      440, 449, 450, 451, 468, 488, 531, 533, 568, 590, 609, 633, 635, 709, 710, 724, 783, 808, 885, 913, 932, 965, 971,
+      1000, 1020, 1085, 1119, 1126, 1137, 1178, 1198, 1241, 1249, 1310, 1326, 1340, 1367, 1372, 1376, 1379, 1428, 1431,
+      1463, 1491, 1521, 1547, 1559, 1591, 1655, 1769, 1851, 1852, 1855, 1868, 1869, 1888, 2085, 2104, 2128, 2138, 2148,
+      2171, 2172, 2182, 2212, 2277, 2334, 2375, 2419, 2437,
+    ],
+    meaning_mnemonic: "<snip>",
+    lesson_position: 0,
+    spaced_repetition_system_id: 2,
+  },
 };
 
 const kanji = {
@@ -847,7 +572,68 @@ const kanji = {
   object: "kanji" as const,
   url: "https://api.wanikani.com/v2/subjects/440",
   data_updated_at: v.parse(DatableString, "2025-01-21T15:25:03.362576Z"),
-  data: kanjiData,
+  data: {
+    created_at: v.parse(DatableString, "2012-02-27T19:55:19.000000Z"),
+    level: 1,
+    slug: "一",
+    hidden_at: null,
+    document_url: "https://www.wanikani.com/kanji/%E4%B8%80",
+    characters: "一",
+    meanings: [
+      {
+        meaning: "One",
+        primary: true,
+        accepted_answer: true,
+      },
+    ],
+    auxiliary_meanings: [
+      {
+        meaning: "1",
+        type: "whitelist" as const,
+      },
+    ],
+    readings: [
+      {
+        reading: "いち",
+        primary: true,
+        accepted_answer: true,
+        type: "onyomi" as const,
+      },
+      {
+        reading: "いつ",
+        primary: false,
+        accepted_answer: true,
+        type: "onyomi" as const,
+      },
+      {
+        reading: "ひと",
+        primary: false,
+        accepted_answer: false,
+        type: "kunyomi" as const,
+      },
+      {
+        reading: "かず",
+        primary: false,
+        accepted_answer: false,
+        type: "nanori" as const,
+      },
+    ],
+    component_subject_ids: [1],
+    amalgamation_subject_ids: [
+      2467, 2468, 2477, 2510, 2544, 2588, 2627, 2660, 2665, 2672, 2679, 2721, 2730, 2751, 2959, 3048, 3256, 3335, 3348,
+      3349, 3372, 3481, 3527, 3528, 3656, 3663, 4133, 4173, 4258, 4282, 4563, 4615, 4701, 4823, 4906, 5050, 5224, 5237,
+      5349, 5362, 5838, 6010, 6029, 6150, 6169, 6209, 6210, 6346, 6584, 6614, 6723, 6811, 6851, 7037, 7293, 7305, 7451,
+      7561, 7617, 7734, 7780, 7927, 8209, 8214, 8414, 8456, 8583, 8709, 8896, 8921, 9056, 9103, 9268, 9286, 9305, 9306,
+      9331,
+    ],
+    visually_similar_subject_ids: [],
+    meaning_mnemonic: "<snip>",
+    meaning_hint: "<snip>",
+    reading_mnemonic: "<snip>",
+    reading_hint: "<snip>",
+    lesson_position: 25,
+    spaced_repetition_system_id: 2,
+  },
 };
 
 const vocabulary = {
@@ -855,7 +641,96 @@ const vocabulary = {
   object: "vocabulary" as const,
   url: "https://api.wanikani.com/v2/subjects/2467",
   data_updated_at: v.parse(DatableString, "2024-10-15T22:13:34.087679Z"),
-  data: vocabularyData,
+  data: {
+    created_at: v.parse(DatableString, "2012-02-28T08:04:47.000000Z"),
+    level: 1,
+    slug: "一",
+    hidden_at: null,
+    document_url: "https://www.wanikani.com/vocabulary/%E4%B8%80",
+    characters: "一",
+    meanings: [
+      {
+        meaning: "One",
+        primary: true,
+        accepted_answer: true,
+      },
+    ],
+    auxiliary_meanings: [
+      {
+        meaning: "1",
+        type: "whitelist" as const,
+      },
+    ],
+    readings: [
+      {
+        reading: "いち",
+        primary: true,
+        accepted_answer: true,
+      },
+    ],
+    parts_of_speech: ["numeral"],
+    component_subject_ids: [440],
+    meaning_mnemonic: "<snip>",
+    reading_mnemonic: "<snip>",
+    context_sentences: [
+      {
+        en: "<snip>",
+        ja: "<snip>",
+      },
+    ],
+    pronunciation_audios: [
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "male" as const,
+          source_id: 2711,
+          pronunciation: "いち",
+          voice_actor_id: 2,
+          voice_actor_name: "Kenichi",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/webm" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "female" as const,
+          source_id: 21630,
+          pronunciation: "いち",
+          voice_actor_id: 1,
+          voice_actor_name: "Kyoko",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/webm" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "female" as const,
+          source_id: 21630,
+          pronunciation: "いち",
+          voice_actor_id: 1,
+          voice_actor_name: "Kyoko",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/mpeg" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "male" as const,
+          source_id: 2711,
+          pronunciation: "いち",
+          voice_actor_id: 2,
+          voice_actor_name: "Kenichi",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/mpeg" as const,
+      },
+    ],
+    lesson_position: 43,
+    spaced_repetition_system_id: 2,
+  },
 };
 
 const kanaVocabulary = {
@@ -863,7 +738,112 @@ const kanaVocabulary = {
   object: "kana_vocabulary" as const,
   url: "https://api.wanikani.com/v2/subjects/9176",
   data_updated_at: v.parse(DatableString, "2024-10-15T22:19:11.286457Z"),
-  data: kanaVocabularyData,
+  data: {
+    created_at: v.parse(DatableString, "2022-09-14T11:39:10.684981Z"),
+    level: 10,
+    slug: "ちょっと",
+    hidden_at: null,
+    document_url: "https://www.wanikani.com/vocabulary/%E3%81%A1%E3%82%87%E3%81%A3%E3%81%A8",
+    characters: "ちょっと",
+    meanings: [
+      {
+        meaning: "A Little",
+        primary: true,
+        accepted_answer: true,
+      },
+      {
+        meaning: "A Moment",
+        primary: false,
+        accepted_answer: true,
+      },
+    ],
+    auxiliary_meanings: [
+      {
+        meaning: "A Bit",
+        type: "whitelist" as const,
+      },
+      {
+        meaning: "A Few",
+        type: "whitelist" as const,
+      },
+      {
+        meaning: "For A Moment",
+        type: "whitelist" as const,
+      },
+      {
+        meaning: "A Minute",
+        type: "whitelist" as const,
+      },
+      {
+        meaning: "For A Minute",
+        type: "whitelist" as const,
+      },
+      {
+        meaning: "Some",
+        type: "whitelist" as const,
+      },
+    ],
+    parts_of_speech: ["adverb"],
+    meaning_mnemonic: "<snip>",
+    context_sentences: [
+      {
+        en: "<snip>",
+        ja: "<snip>",
+      },
+    ],
+    pronunciation_audios: [
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "female" as const,
+          source_id: 44712,
+          pronunciation: "ちょっと",
+          voice_actor_id: 1,
+          voice_actor_name: "Kyoko",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/webm" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "female" as const,
+          source_id: 44712,
+          pronunciation: "ちょっと",
+          voice_actor_id: 1,
+          voice_actor_name: "Kyoko",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/mpeg" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "male" as const,
+          source_id: 44771,
+          pronunciation: "ちょっと",
+          voice_actor_id: 2,
+          voice_actor_name: "Kenichi",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/webm" as const,
+      },
+      {
+        url: "https://example.com",
+        metadata: {
+          gender: "male" as const,
+          source_id: 44771,
+          pronunciation: "ちょっと",
+          voice_actor_id: 2,
+          voice_actor_name: "Kenichi",
+          voice_description: "Tokyo accent",
+        },
+        content_type: "audio/mpeg" as const,
+      },
+    ],
+    lesson_position: 59,
+    spaced_repetition_system_id: 1,
+  },
 };
 
 const radicalCollection = {
@@ -1006,7 +986,6 @@ export const testFor = test.extend({
   collectionParamsWithManyOptions,
   collectionParamsWithDates,
   collectionParamsWithDatableStrings,
-  assignmentData,
   assignment,
   assignmentCollection,
   assignmentParamsWithEmptyArrays,
@@ -1016,21 +995,17 @@ export const testFor = test.extend({
   assignmentPayloadWithNoTime,
   assignmentPayloadWithDate,
   assignmentPayloadWithDatableString,
-  levelProgressionData,
   levelProgression,
   levelProgressionCollection,
   requestFactory,
-  resetData,
   reset,
   resetCollection,
-  reviewStatisticData,
   reviewStatistic,
   reviewStatisticCollection,
   reviewStatisticParamsWithEmptyArrays,
   reviewStatisticParamsWithManyOptions,
   reviewStatisticParamsWithDates,
   reviewStatisticParamsWithDatableStrings,
-  reviewData,
   review,
   reviewCollection,
   reviewParamsWithEmptyArrays,
@@ -1042,13 +1017,8 @@ export const testFor = test.extend({
   reviewPayloadWithSubjectAndDate,
   reviewPayloadWithSubjectAndDatableStrings,
   spacedRepetitionSystemStageNumbers,
-  spacedRepetitionSystemData,
   spacedRepetitionSystem,
   spacedRepetitionSystemCollection,
-  radicalData,
-  kanjiData,
-  vocabularyData,
-  kanaVocabularyData,
   radical,
   kanji,
   vocabulary,

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1,28 +1,28 @@
 import * as v from "valibot";
-import { type CollectionParameters, DatableString } from "../../src/base/v20170710";
+import { type CollectionParameters, DatableString } from "../../src/base/v20170710.js";
 import { test } from "vitest";
 
 const emptyParams: CollectionParameters = {};
 
 const assignmentData = {
-  created_at: "2017-10-22T15:41:43.861883Z",
+  created_at: v.parse(DatableString, "2017-10-22T15:41:43.861883Z"),
   subject_id: 8761,
   subject_type: "radical",
   srs_stage: 9,
-  unlocked_at: "2021-07-22T21:03:22.905689Z",
-  started_at: "2021-07-30T15:11:42.594913Z",
-  passed_at: "2021-08-01T04:32:27.017606Z",
-  burned_at: "2022-01-20T20:03:37.269028Z",
+  unlocked_at: v.parse(DatableString, "2021-07-22T21:03:22.905689Z"),
+  started_at: v.parse(DatableString, "2021-07-30T15:11:42.594913Z"),
+  passed_at: v.parse(DatableString, "2021-08-01T04:32:27.017606Z"),
+  burned_at: v.parse(DatableString, "2022-01-20T20:03:37.269028Z"),
   available_at: null,
   resurrected_at: null,
   hidden: false,
-};
+} as const;
 
 const assignment = {
   id: 85041695,
   object: "assignment",
   url: "https://api.wanikani.com/v2/assignments/85041695",
-  data_updated_at: "2025-01-22T18:06:08.895692Z",
+  data_updated_at: v.parse(DatableString, "2025-01-22T18:06:08.895692Z"),
   data: assignmentData,
 };
 
@@ -35,7 +35,7 @@ const assignmentCollection = {
     previous_url: null,
   },
   total_count: 6055,
-  data_updated_at: "2025-02-15T22:19:50.167435Z",
+  data_updated_at: v.parse(DatableString, "2025-02-15T22:19:50.167435Z"),
   data: [assignment],
 };
 

--- a/tests/level-progressions/v20170710.test-d.ts
+++ b/tests/level-progressions/v20170710.test-d.ts
@@ -1,16 +1,6 @@
-import type {
-  LevelProgression,
-  LevelProgressionCollection,
-  LevelProgressionData,
-} from "../../src/level-progressions/v20170710.js";
+import type { LevelProgression, LevelProgressionCollection } from "../../src/level-progressions/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("LevelProgressionData", () => {
-  testFor("Real LevelProgressionData", ({ levelProgressionData }) => {
-    assertType<LevelProgressionData>(levelProgressionData);
-  });
-});
 
 describe("LevelProgression", () => {
   testFor("Real LevelProgression", ({ levelProgression }) => {

--- a/tests/level-progressions/v20170710.test-d.ts
+++ b/tests/level-progressions/v20170710.test-d.ts
@@ -1,0 +1,25 @@
+import type {
+  LevelProgression,
+  LevelProgressionCollection,
+  LevelProgressionData,
+} from "../../src/level-progressions/v20170710.js";
+import { assertType, describe } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("LevelProgressionData", () => {
+  testFor("Real LevelProgressionData", ({ levelProgressionData }) => {
+    assertType<LevelProgressionData>(levelProgressionData);
+  });
+});
+
+describe("LevelProgression", () => {
+  testFor("Real LevelProgression", ({ levelProgression }) => {
+    assertType<LevelProgression>(levelProgression);
+  });
+});
+
+describe("LevelProgressionCollection", () => {
+  testFor("Real LevelProgressionCollection", ({ levelProgressionCollection }) => {
+    assertType<LevelProgressionCollection>(levelProgressionCollection);
+  });
+});

--- a/tests/level-progressions/v20170710.test.ts
+++ b/tests/level-progressions/v20170710.test.ts
@@ -1,17 +1,7 @@
 import * as v from "valibot";
-import {
-  LevelProgression,
-  LevelProgressionCollection,
-  LevelProgressionData,
-} from "../../src/level-progressions/v20170710.js";
+import { LevelProgression, LevelProgressionCollection } from "../../src/level-progressions/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("LevelProgressionData", () => {
-  testFor("Real LevelProgressionData", ({ levelProgressionData }) => {
-    expect(() => v.assert(LevelProgressionData, levelProgressionData)).not.toThrow();
-  });
-});
 
 describe("LevelProgression", () => {
   testFor("Real LevelProgression", ({ levelProgression }) => {

--- a/tests/level-progressions/v20170710.test.ts
+++ b/tests/level-progressions/v20170710.test.ts
@@ -1,0 +1,26 @@
+import * as v from "valibot";
+import {
+  LevelProgression,
+  LevelProgressionCollection,
+  LevelProgressionData,
+} from "../../src/level-progressions/v20170710.js";
+import { describe, expect } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("LevelProgressionData", () => {
+  testFor("Real LevelProgressionData", ({ levelProgressionData }) => {
+    expect(() => v.assert(LevelProgressionData, levelProgressionData)).not.toThrow();
+  });
+});
+
+describe("LevelProgression", () => {
+  testFor("Real LevelProgression", ({ levelProgression }) => {
+    expect(() => v.assert(LevelProgression, levelProgression)).not.toThrow();
+  });
+});
+
+describe("LevelProgressionCollection", () => {
+  testFor("Real LevelProgressionCollection", ({ levelProgressionCollection }) => {
+    expect(() => v.assert(LevelProgressionCollection, levelProgressionCollection)).not.toThrow();
+  });
+});

--- a/tests/requests/v20170710.test-d.ts
+++ b/tests/requests/v20170710.test-d.ts
@@ -1,0 +1,122 @@
+import { describe, expectTypeOf } from "vitest";
+import type { ApiRequest } from "../../src/requests/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("ApiRequestFactory", () => {
+  testFor("Return Type for Get Assignment Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.assignments.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Assignment", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.assignments.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Start Assignment", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.assignments.start(1, { assignment: {} })).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Level Progression Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.levelProgressions.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Level Progression", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.levelProgressions.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Reset Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.resets.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Reset", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.resets.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Review Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.reviews.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Review", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.reviews.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Create Review", ({ requestFactory }) => {
+    expectTypeOf(
+      requestFactory.reviews.create({
+        review: {
+          subject_id: 1,
+          incorrect_meaning_answers: 0,
+          incorrect_reading_answers: 0,
+        },
+      }),
+    ).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Review Statistic Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.reviewStatistics.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Review Statistic", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.reviewStatistics.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Spaced Repetition System Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.spacedRepetitionSystems.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Spaced Repetition System", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.spacedRepetitionSystems.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Study Material Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.studyMaterials.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Study Material", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.studyMaterials.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Create Study Material", ({ requestFactory }) => {
+    expectTypeOf(
+      requestFactory.studyMaterials.create({
+        subject_id: 123,
+        meaning_note: "A note",
+        reading_note: "B note",
+        meaning_synonyms: ["one", "two", "three"],
+      }),
+    ).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Update Study Material", ({ requestFactory }) => {
+    expectTypeOf(
+      requestFactory.studyMaterials.update(1, {
+        meaning_note: "A note",
+        reading_note: "B note",
+        meaning_synonyms: ["one", "two", "three"],
+      }),
+    ).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Subject Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.subjects.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Subject", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.subjects.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Summary", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.summary.get()).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get User", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.user.get()).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Update User", ({ requestFactory }) => {
+    expectTypeOf(
+      requestFactory.user.updatePreferences({
+        user: {
+          preferences: {
+            default_voice_actor_id: 1,
+            lessons_autoplay_audio: true,
+            lessons_batch_size: 10,
+          },
+        },
+      }),
+    ).toEqualTypeOf<ApiRequest>();
+  });
+
+  testFor("Return Type for Get Voice Actor Collection", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.voiceActors.get({ ids: [1] })).toEqualTypeOf<ApiRequest>();
+  });
+  testFor("Return Type for Get Voice Actor", ({ requestFactory }) => {
+    expectTypeOf(requestFactory.voiceActors.get(1)).toEqualTypeOf<ApiRequest>();
+  });
+});

--- a/tests/requests/v20170710.test.ts
+++ b/tests/requests/v20170710.test.ts
@@ -1,20 +1,19 @@
 import { describe, expect, test } from "vitest";
-import type { AssignmentParameters, AssignmentPayload } from "../../src/assignments/v20170710";
-import type { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710";
+import type { AssignmentParameters, AssignmentPayload } from "../../src/assignments/v20170710.js";
+import type { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
 import type {
   StudyMaterialCreatePayload,
   StudyMaterialParameters,
   StudyMaterialUpdatePayload,
-} from "../../src/study-materials/v20170710";
-import type { LevelProgressionParameters } from "../../src/level-progressions/v20170710";
-import type { ResetParameters } from "../../src/resets/v20170710";
-import type { ReviewStatisticParameters } from "../../src/review-statistics/v20170710";
-import type { SpacedRepetitionSystemParameters } from "../../src/spaced-repetition-systems/v20170710";
-import type { SubjectParameters } from "../../src/subjects/v20170710";
-import type { UserPreferencesPayload } from "../../src/user/v20170710";
-import type { VoiceActorParameters } from "../../src/voice-actors/v20170710";
-import { ApiRequestFactory, type ApiRequestOptions } from "../../src/requests/v20170710";
-import { factory } from "typescript";
+} from "../../src/study-materials/v20170710.js";
+import type { LevelProgressionParameters } from "../../src/level-progressions/v20170710.js";
+import type { ResetParameters } from "../../src/resets/v20170710.js";
+import type { ReviewStatisticParameters } from "../../src/review-statistics/v20170710.js";
+import type { SpacedRepetitionSystemParameters } from "../../src/spaced-repetition-systems/v20170710.js";
+import type { SubjectParameters } from "../../src/subjects/v20170710.js";
+import type { UserPreferencesPayload } from "../../src/user/v20170710.js";
+import type { VoiceActorParameters } from "../../src/voice-actors/v20170710.js";
+import { ApiRequestFactory, type ApiRequestOptions } from "../../src/requests/v20170710.js";
 
 describe("ApiRequestFactory", () => {
   const getOptions: ApiRequestOptions = {

--- a/tests/requests/v20170710.test.ts
+++ b/tests/requests/v20170710.test.ts
@@ -6,7 +6,7 @@ import type {
   StudyMaterialParameters,
   StudyMaterialUpdatePayload,
 } from "../../src/study-materials/v20170710.js";
-import { describe, expect, test } from "vitest";
+import { describe, expect } from "vitest";
 import type { LevelProgressionParameters } from "../../src/level-progressions/v20170710.js";
 import type { ResetParameters } from "../../src/resets/v20170710.js";
 import type { ReviewStatisticParameters } from "../../src/review-statistics/v20170710.js";
@@ -14,6 +14,7 @@ import type { SpacedRepetitionSystemParameters } from "../../src/spaced-repetiti
 import type { SubjectParameters } from "../../src/subjects/v20170710.js";
 import type { UserPreferencesPayload } from "../../src/user/v20170710.js";
 import type { VoiceActorParameters } from "../../src/voice-actors/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
 
 describe("ApiRequestFactory", () => {
   const getOptions: ApiRequestOptions = {
@@ -30,9 +31,7 @@ describe("ApiRequestFactory", () => {
     },
   };
 
-  const wanikani = new ApiRequestFactory({ apiToken: "abc", revision: "20170710" });
-
-  test("Returns GET request for an Assignment Collection", () => {
+  testFor("Returns GET request for an Assignment Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/assignments";
     const expectedUrl2 = "https://api.wanikani.com/v2/assignments?unlocked=true&hidden=false";
@@ -54,8 +53,8 @@ describe("ApiRequestFactory", () => {
       hidden: false,
     };
 
-    const request1 = wanikani.assignments.get({}, getOptions);
-    const request2 = wanikani.assignments.get(params);
+    const request1 = requestFactory.assignments.get({}, getOptions);
+    const request2 = requestFactory.assignments.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -68,7 +67,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for an Assignment", () => {
+  testFor("Returns GET request for an Assignment", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/assignments/123";
     const expectedHeaders = {
@@ -77,7 +76,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.assignments.get(123);
+    const request = requestFactory.assignments.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -85,7 +84,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns PUT request for starting an Assignment", () => {
+  testFor("Returns PUT request for starting an Assignment", ({ requestFactory }) => {
     const expectedMethod = "PUT";
     const expectedUrl = "https://api.wanikani.com/v2/assignments/123/start";
     const expectedHeaders = {
@@ -102,7 +101,7 @@ describe("ApiRequestFactory", () => {
       },
     };
 
-    const request = wanikani.assignments.start(123, payload, putPostOptions);
+    const request = requestFactory.assignments.start(123, payload, putPostOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -110,7 +109,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Level Progression Collection", () => {
+  testFor("Returns GET request for a Level Progression Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/level_progressions";
     const expectedUrl2 =
@@ -133,8 +132,8 @@ describe("ApiRequestFactory", () => {
       updated_after: new Date("2023-03-01T12:00:00.000Z"),
     };
 
-    const request1 = wanikani.levelProgressions.get({}, getOptions);
-    const request2 = wanikani.levelProgressions.get(params);
+    const request1 = requestFactory.levelProgressions.get({}, getOptions);
+    const request2 = requestFactory.levelProgressions.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -147,7 +146,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Level Progression", () => {
+  testFor("Returns GET request for a Level Progression", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/level_progressions/123";
     const expectedHeaders = {
@@ -156,7 +155,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.levelProgressions.get(123);
+    const request = requestFactory.levelProgressions.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -164,7 +163,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Reset Collection", () => {
+  testFor("Returns GET request for a Reset Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/resets";
     const expectedUrl2 = "https://api.wanikani.com/v2/resets?ids=1,2,3&updated_after=2023-03-01T12:00:00.000Z";
@@ -186,8 +185,8 @@ describe("ApiRequestFactory", () => {
       updated_after: new Date("2023-03-01T12:00:00.000Z"),
     };
 
-    const request1 = wanikani.resets.get({}, getOptions);
-    const request2 = wanikani.resets.get(params);
+    const request1 = requestFactory.resets.get({}, getOptions);
+    const request2 = requestFactory.resets.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -200,7 +199,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Reset", () => {
+  testFor("Returns GET request for a Reset", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/resets/123";
     const expectedHeaders = {
@@ -209,7 +208,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.resets.get(123);
+    const request = requestFactory.resets.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -217,7 +216,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Review Collection", () => {
+  testFor("Returns GET request for a Review Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/reviews";
     const expectedUrl2 = "https://api.wanikani.com/v2/reviews?assignment_ids=1,2,3&subject_ids=4,5,6";
@@ -239,8 +238,8 @@ describe("ApiRequestFactory", () => {
       subject_ids: [4, 5, 6],
     };
 
-    const request1 = wanikani.reviews.get({}, getOptions);
-    const request2 = wanikani.reviews.get(params);
+    const request1 = requestFactory.reviews.get({}, getOptions);
+    const request2 = requestFactory.reviews.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -253,7 +252,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Review", () => {
+  testFor("Returns GET request for a Review", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/reviews/123";
     const expectedHeaders = {
@@ -262,7 +261,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.reviews.get(123);
+    const request = requestFactory.reviews.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -270,7 +269,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns POST request for creating a Review", () => {
+  testFor("Returns POST request for creating a Review", ({ requestFactory }) => {
     const expectedMethod = "POST";
     const expectedUrl = "https://api.wanikani.com/v2/reviews";
     const expectedHeaders = {
@@ -289,7 +288,7 @@ describe("ApiRequestFactory", () => {
       },
     };
 
-    const request = wanikani.reviews.create(payload, putPostOptions);
+    const request = requestFactory.reviews.create(payload, putPostOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -297,7 +296,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Review Statistic Collection", () => {
+  testFor("Returns GET request for a Review Statistic Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/review_statistics";
     const expectedUrl2 = "https://api.wanikani.com/v2/review_statistics?subject_ids=1,2,3&percentages_greater_than=90";
@@ -319,8 +318,8 @@ describe("ApiRequestFactory", () => {
       percentages_greater_than: 90,
     };
 
-    const request1 = wanikani.reviewStatistics.get({}, getOptions);
-    const request2 = wanikani.reviewStatistics.get(params);
+    const request1 = requestFactory.reviewStatistics.get({}, getOptions);
+    const request2 = requestFactory.reviewStatistics.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -333,7 +332,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Review Statistic", () => {
+  testFor("Returns GET request for a Review Statistic", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/review_statistics/123";
     const expectedHeaders = {
@@ -342,7 +341,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.reviewStatistics.get(123);
+    const request = requestFactory.reviewStatistics.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -350,7 +349,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Spaced repetition System Collection", () => {
+  testFor("Returns GET request for a Spaced Repetition System Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/spaced_repetition_systems";
     const expectedUrl2 =
@@ -373,8 +372,8 @@ describe("ApiRequestFactory", () => {
       updated_after: new Date("2023-03-01T12:00:00.000Z"),
     };
 
-    const request1 = wanikani.spacedRepetitionSystems.get({}, getOptions);
-    const request2 = wanikani.spacedRepetitionSystems.get(params);
+    const request1 = requestFactory.spacedRepetitionSystems.get({}, getOptions);
+    const request2 = requestFactory.spacedRepetitionSystems.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -387,7 +386,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Spaced repetition System", () => {
+  testFor("Returns GET request for a Spaced Repetition System", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/spaced_repetition_systems/123";
     const expectedHeaders = {
@@ -396,7 +395,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request1 = wanikani.spacedRepetitionSystems.get(123);
+    const request1 = requestFactory.spacedRepetitionSystems.get(123);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl);
@@ -404,7 +403,7 @@ describe("ApiRequestFactory", () => {
     expect(request1.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Study Material Collection", () => {
+  testFor("Returns GET request for a Study Material Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/study_materials";
     const expectedUrl2 = "https://api.wanikani.com/v2/study_materials?subject_ids=1,2,3&subject_types=kanji";
@@ -426,8 +425,8 @@ describe("ApiRequestFactory", () => {
       subject_types: ["kanji"],
     };
 
-    const request1 = wanikani.studyMaterials.get({}, getOptions);
-    const request2 = wanikani.studyMaterials.get(params);
+    const request1 = requestFactory.studyMaterials.get({}, getOptions);
+    const request2 = requestFactory.studyMaterials.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -440,7 +439,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Study Material", () => {
+  testFor("Returns GET request for a Study Material", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/study_materials/123";
     const expectedHeaders = {
@@ -449,7 +448,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.studyMaterials.get(123);
+    const request = requestFactory.studyMaterials.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -457,7 +456,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns POST request for creating a Study Material", () => {
+  testFor("Returns POST request for creating a Study Material", ({ requestFactory }) => {
     const expectedMethod = "POST";
     const expectedUrl = "https://api.wanikani.com/v2/study_materials";
     const expectedHeaders = {
@@ -475,7 +474,7 @@ describe("ApiRequestFactory", () => {
       meaning_synonyms: ["one", "two", "three"],
     };
 
-    const request = wanikani.studyMaterials.create(payload, putPostOptions);
+    const request = requestFactory.studyMaterials.create(payload, putPostOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -483,7 +482,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns PUT request for updating a Study Material", () => {
+  testFor("Returns PUT request for updating a Study Material", ({ requestFactory }) => {
     const expectedMethod = "PUT";
     const expectedUrl = "https://api.wanikani.com/v2/study_materials/123";
     const expectedHeaders = {
@@ -500,7 +499,7 @@ describe("ApiRequestFactory", () => {
       meaning_synonyms: ["one", "two", "three"],
     };
 
-    const request = wanikani.studyMaterials.update(123, payload, putPostOptions);
+    const request = requestFactory.studyMaterials.update(123, payload, putPostOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -508,7 +507,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Subject Collection", () => {
+  testFor("Returns GET request for a Subject Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/subjects";
     const expectedUrl2 = "https://api.wanikani.com/v2/subjects?types=radical,kanji&levels=1,2,3";
@@ -530,8 +529,8 @@ describe("ApiRequestFactory", () => {
       levels: [1, 2, 3],
     };
 
-    const request1 = wanikani.subjects.get({}, getOptions);
-    const request2 = wanikani.subjects.get(params);
+    const request1 = requestFactory.subjects.get({}, getOptions);
+    const request2 = requestFactory.subjects.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -544,7 +543,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Subject", () => {
+  testFor("Returns GET request for a Subject", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/subjects/123";
     const expectedHeaders = {
@@ -553,7 +552,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.subjects.get(123);
+    const request = requestFactory.subjects.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -561,7 +560,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Summary", () => {
+  testFor("Returns GET request for a Summary", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/summary";
     const expectedHeaders = {
@@ -573,7 +572,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.summary.get(getOptions);
+    const request = requestFactory.summary.get(getOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -581,7 +580,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a User", () => {
+  testFor("Returns GET request for a User", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/user";
     const expectedHeaders = {
@@ -593,7 +592,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.user.get(getOptions);
+    const request = requestFactory.user.get(getOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -601,7 +600,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns PUT request for updating a User", () => {
+  testFor("Returns PUT request for updating a User", ({ requestFactory }) => {
     const expectedMethod = "PUT";
     const expectedUrl = "https://api.wanikani.com/v2/user";
     const expectedHeaders = {
@@ -622,7 +621,7 @@ describe("ApiRequestFactory", () => {
       },
     };
 
-    const request = wanikani.user.updatePreferences(payload, putPostOptions);
+    const request = requestFactory.user.updatePreferences(payload, putPostOptions);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -630,7 +629,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Voice Actor Collection", () => {
+  testFor("Returns GET request for a Voice Actor Collection", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/voice_actors";
     const expectedUrl2 = "https://api.wanikani.com/v2/voice_actors?ids=1,2,3&updated_after=2023-03-01T12:00:00.000Z";
@@ -652,8 +651,8 @@ describe("ApiRequestFactory", () => {
       updated_after: new Date("2023-03-01T12:00:00.000Z"),
     };
 
-    const request1 = wanikani.voiceActors.get({}, getOptions);
-    const request2 = wanikani.voiceActors.get(params);
+    const request1 = requestFactory.voiceActors.get({}, getOptions);
+    const request2 = requestFactory.voiceActors.get(params);
 
     expect(request1.method).toBe(expectedMethod);
     expect(request1.url).toBe(expectedUrl1);
@@ -666,7 +665,7 @@ describe("ApiRequestFactory", () => {
     expect(request2.body).toBe(expectedBody);
   });
 
-  test("Returns GET request for a Voice Actor", () => {
+  testFor("Returns GET request for a Voice Actor", ({ requestFactory }) => {
     const expectedMethod = "GET";
     const expectedUrl = "https://api.wanikani.com/v2/voice_actors/123";
     const expectedHeaders = {
@@ -675,7 +674,7 @@ describe("ApiRequestFactory", () => {
     };
     const expectedBody = null;
 
-    const request = wanikani.voiceActors.get(123);
+    const request = requestFactory.voiceActors.get(123);
 
     expect(request.method).toBe(expectedMethod);
     expect(request.url).toBe(expectedUrl);
@@ -683,7 +682,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Changes API Token using setApiToken()", () => {
+  testFor("Changes API Token using setApiToken()", () => {
     const expectedHeaders = {
       authorization: "Bearer def",
       "wanikani-revision": "20170710",
@@ -694,18 +693,18 @@ describe("ApiRequestFactory", () => {
     expect(request.headers).toStrictEqual(expectedHeaders);
   });
 
-  test("Changes API Revision with setApiRevision()", () => {
+  testFor("Changes API Revision with setApiRevision()", () => {
     const factory = new ApiRequestFactory({ apiToken: "abc" });
     expect(() => factory.setApiRevision("20170710")).not.toThrow();
   });
 
-  test("Throws when trying to set invalid API Revision", () => {
+  testFor("Throws when trying to set invalid API Revision", () => {
     const factory = new ApiRequestFactory({ apiToken: "abc" });
     // @ts-expect-error -- Setting an invalid API Revision
     expect(() => factory.setApiRevision("20990909")).toThrow();
   });
 
-  test("Adds any new headers to requests using addCustomHeaders()", () => {
+  testFor("Adds any new headers to requests using addCustomHeaders()", () => {
     const customHeaders1 = {
       "x-forwarded-for": "192.168.1.1",
     };
@@ -723,7 +722,7 @@ describe("ApiRequestFactory", () => {
     expect(request.headers).toStrictEqual(expectedHeaders);
   });
 
-  test("Replaces custom headers only wtesth setCustomHeaders()", () => {
+  testFor("Replaces custom headers only wtesth setCustomHeaders()", () => {
     const customHeaders1 = {
       "x-forwarded-for": "192.168.1.1",
     };
@@ -740,7 +739,7 @@ describe("ApiRequestFactory", () => {
     expect(request.headers).toStrictEqual(expectedHeaders);
   });
 
-  test("Throws when trying to set type-checked headers", () => {
+  testFor("Throws when trying to set type-checked headers", () => {
     const factory = new ApiRequestFactory({ apiToken: "abc" });
     expect(() => factory.addCustomHeaders({ authorization: "Cheese" })).toThrow(
       "WaniKani API Token should be set via setApiToken() method.",

--- a/tests/requests/v20170710.test.ts
+++ b/tests/requests/v20170710.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { ApiRequestFactory, type ApiRequestOptions } from "../../src/requests/v20170710.js";
 import type { AssignmentParameters, AssignmentPayload } from "../../src/assignments/v20170710.js";
 import type { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
 import type {
@@ -6,6 +6,7 @@ import type {
   StudyMaterialParameters,
   StudyMaterialUpdatePayload,
 } from "../../src/study-materials/v20170710.js";
+import { describe, expect, test } from "vitest";
 import type { LevelProgressionParameters } from "../../src/level-progressions/v20170710.js";
 import type { ResetParameters } from "../../src/resets/v20170710.js";
 import type { ReviewStatisticParameters } from "../../src/review-statistics/v20170710.js";
@@ -13,14 +14,13 @@ import type { SpacedRepetitionSystemParameters } from "../../src/spaced-repetiti
 import type { SubjectParameters } from "../../src/subjects/v20170710.js";
 import type { UserPreferencesPayload } from "../../src/user/v20170710.js";
 import type { VoiceActorParameters } from "../../src/voice-actors/v20170710.js";
-import { ApiRequestFactory, type ApiRequestOptions } from "../../src/requests/v20170710.js";
 
 describe("ApiRequestFactory", () => {
   const getOptions: ApiRequestOptions = {
     customHeaders: {
       "x-forwarded-for": "192.168.1.1",
       "if-modified-since": "Tue, 14 Mar 2023, 12:00:00 GMT",
-      "if-none-match": `W/"70abc5970f2ab8cd34adcfad015ffde6\"`,
+      "if-none-match": `W/"70abc5970f2ab8cd34adcfad015ffde6"`,
     },
   };
 
@@ -701,7 +701,7 @@ describe("ApiRequestFactory", () => {
 
   test("Throws when trying to set invalid API Revision", () => {
     const factory = new ApiRequestFactory({ apiToken: "abc" });
-    // @ts-expect-error
+    // @ts-expect-error -- Setting an invalid API Revision
     expect(() => factory.setApiRevision("20990909")).toThrow();
   });
 

--- a/tests/requests/v20170710.test.ts
+++ b/tests/requests/v20170710.test.ts
@@ -36,7 +36,7 @@ describe("ApiRequestFactory", () => {
   test("Returns GET request for an Assignment Collection", () => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/assignments";
-    const expectedUrl2 = "https://api.wanikani.com/v2/assignments?hidden=false&unlocked=true";
+    const expectedUrl2 = "https://api.wanikani.com/v2/assignments?unlocked=true&hidden=false";
     const expectedHeaders1 = {
       authorization: "Bearer abc",
       "wanikani-revision": "20170710",
@@ -271,7 +271,7 @@ describe("ApiRequestFactory", () => {
     expect(request.body).toBe(expectedBody);
   });
 
-  test("Returns POST request for creating a Reviews", () => {
+  test("Returns POST request for creating a Review", () => {
     const expectedMethod = "POST";
     const expectedUrl = "https://api.wanikani.com/v2/reviews";
     const expectedHeaders = {
@@ -280,7 +280,7 @@ describe("ApiRequestFactory", () => {
       "content-type": "application/json",
       "x-forwarded-for": "192.168.1.1",
     };
-    const expectedBody = `{"review":{"incorrect_meaning_answers":0,"incorrect_reading_answers":0,"subject_id":123}}`;
+    const expectedBody = `{"review":{"subject_id":123,"incorrect_meaning_answers":0,"incorrect_reading_answers":0}}`;
 
     const payload: ReviewPayload = {
       review: {
@@ -301,7 +301,7 @@ describe("ApiRequestFactory", () => {
   test("Returns GET request for a Review Statistic Collection", () => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/review_statistics";
-    const expectedUrl2 = "https://api.wanikani.com/v2/review_statistics?percentages_greater_than=90&subject_ids=1,2,3";
+    const expectedUrl2 = "https://api.wanikani.com/v2/review_statistics?subject_ids=1,2,3&percentages_greater_than=90";
     const expectedHeaders1 = {
       authorization: "Bearer abc",
       "wanikani-revision": "20170710",
@@ -467,7 +467,7 @@ describe("ApiRequestFactory", () => {
       "content-type": "application/json",
       "x-forwarded-for": "192.168.1.1",
     };
-    const expectedBody = `{"meaning_note":"A note","meaning_synonyms":["one","two","three"],"reading_note":"B note","subject_id":123}`;
+    const expectedBody = `{"subject_id":123,"meaning_note":"A note","reading_note":"B note","meaning_synonyms":["one","two","three"]}`;
 
     const payload: StudyMaterialCreatePayload = {
       subject_id: 123,
@@ -493,7 +493,7 @@ describe("ApiRequestFactory", () => {
       "content-type": "application/json",
       "x-forwarded-for": "192.168.1.1",
     };
-    const expectedBody = `{"meaning_note":"A note","meaning_synonyms":["one","two","three"],"reading_note":"B note"}`;
+    const expectedBody = `{"meaning_note":"A note","reading_note":"B note","meaning_synonyms":["one","two","three"]}`;
 
     const payload: StudyMaterialUpdatePayload = {
       meaning_note: "A note",
@@ -512,7 +512,7 @@ describe("ApiRequestFactory", () => {
   test("Returns GET request for a Subject Collection", () => {
     const expectedMethod = "GET";
     const expectedUrl1 = "https://api.wanikani.com/v2/subjects";
-    const expectedUrl2 = "https://api.wanikani.com/v2/subjects?levels=1,2,3&types=radical,kanji";
+    const expectedUrl2 = "https://api.wanikani.com/v2/subjects?types=radical,kanji&levels=1,2,3";
     const expectedHeaders1 = {
       authorization: "Bearer abc",
       "wanikani-revision": "20170710",

--- a/tests/resets/v20170710.test-d.ts
+++ b/tests/resets/v20170710.test-d.ts
@@ -1,12 +1,6 @@
-import type { Reset, ResetCollection, ResetData } from "../../src/resets/v20170710.js";
+import type { Reset, ResetCollection } from "../../src/resets/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ResetData", () => {
-  testFor("Real ResetData", ({ resetData }) => {
-    assertType<ResetData>(resetData);
-  });
-});
 
 describe("Reset", () => {
   testFor("Real Reset", ({ reset }) => {

--- a/tests/resets/v20170710.test-d.ts
+++ b/tests/resets/v20170710.test-d.ts
@@ -1,0 +1,21 @@
+import type { Reset, ResetCollection, ResetData } from "../../src/resets/v20170710.js";
+import { assertType, describe } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("ResetData", () => {
+  testFor("Real ResetData", ({ resetData }) => {
+    assertType<ResetData>(resetData);
+  });
+});
+
+describe("Reset", () => {
+  testFor("Real Reset", ({ reset }) => {
+    assertType<Reset>(reset);
+  });
+});
+
+describe("ResetCollection", () => {
+  testFor("Real ResetCollection", ({ resetCollection }) => {
+    assertType<ResetCollection>(resetCollection);
+  });
+});

--- a/tests/resets/v20170710.test.ts
+++ b/tests/resets/v20170710.test.ts
@@ -1,13 +1,7 @@
 import * as v from "valibot";
-import { Reset, ResetCollection, ResetData } from "../../src/resets/v20170710.js";
+import { Reset, ResetCollection } from "../../src/resets/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ResetData", () => {
-  testFor("Real ResetData", ({ resetData }) => {
-    expect(() => v.assert(ResetData, resetData)).not.toThrow();
-  });
-});
 
 describe("Reset", () => {
   testFor("Real Reset", ({ reset }) => {

--- a/tests/resets/v20170710.test.ts
+++ b/tests/resets/v20170710.test.ts
@@ -1,0 +1,22 @@
+import * as v from "valibot";
+import { Reset, ResetCollection, ResetData } from "../../src/resets/v20170710.js";
+import { describe, expect } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("ResetData", () => {
+  testFor("Real ResetData", ({ resetData }) => {
+    expect(() => v.assert(ResetData, resetData)).not.toThrow();
+  });
+});
+
+describe("Reset", () => {
+  testFor("Real Reset", ({ reset }) => {
+    expect(() => v.assert(Reset, reset)).not.toThrow();
+  });
+});
+
+describe("ResetCollection", () => {
+  testFor("Real ResetCollection", ({ resetCollection }) => {
+    expect(() => v.assert(ResetCollection, resetCollection)).not.toThrow();
+  });
+});

--- a/tests/review-statistics/v20170710.test-d.ts
+++ b/tests/review-statistics/v20170710.test-d.ts
@@ -1,45 +1,44 @@
-import * as v from "valibot";
-import {
+import type {
   ReviewStatistic,
   ReviewStatisticCollection,
   ReviewStatisticData,
   ReviewStatisticParameters,
 } from "../../src/review-statistics/v20170710.js";
-import { describe, expect } from "vitest";
+import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("ReviewStatisticData", () => {
   testFor("Real ReviewStatisticData", ({ reviewStatisticData }) => {
-    expect(() => v.parse(ReviewStatisticData, reviewStatisticData)).not.toThrow();
+    assertType<ReviewStatisticData>(reviewStatisticData);
   });
 });
 
 describe("ReviewStatistic", () => {
   testFor("Real ReviewStatistic", ({ reviewStatistic }) => {
-    expect(() => v.parse(ReviewStatistic, reviewStatistic)).not.toThrow();
+    assertType<ReviewStatistic>(reviewStatistic);
   });
 });
 
 describe("ReviewStatisticCollection", () => {
   testFor("Real ReviewStatisticCollection", ({ reviewStatisticCollection }) => {
-    expect(() => v.parse(ReviewStatisticCollection, reviewStatisticCollection)).not.toThrow();
+    assertType<ReviewStatisticCollection>(reviewStatisticCollection);
   });
 });
 
 describe("ReviewStatisticParameters", () => {
   testFor("Empty ReviewStatisticParameters", ({ emptyParams }) => {
-    expect(() => v.assert(ReviewStatisticParameters, emptyParams)).not.toThrow();
+    assertType<ReviewStatisticParameters>(emptyParams);
   });
   testFor("ReviewStatisticParameters with empty arrays", ({ reviewStatisticParamsWithEmptyArrays }) => {
-    expect(() => v.assert(ReviewStatisticParameters, reviewStatisticParamsWithEmptyArrays)).not.toThrow();
+    assertType<ReviewStatisticParameters>(reviewStatisticParamsWithEmptyArrays);
   });
   testFor("ReviewStatisticParameters with many options filled", ({ reviewStatisticParamsWithManyOptions }) => {
-    expect(() => v.assert(ReviewStatisticParameters, reviewStatisticParamsWithManyOptions)).not.toThrow();
+    assertType<ReviewStatisticParameters>(reviewStatisticParamsWithManyOptions);
   });
   testFor("ReviewStatisticParameters with Date objects", ({ reviewStatisticParamsWithDates }) => {
-    expect(() => v.assert(ReviewStatisticParameters, reviewStatisticParamsWithDates)).not.toThrow();
+    assertType<ReviewStatisticParameters>(reviewStatisticParamsWithDates);
   });
   testFor("ReviewStatisticParameters with DatableString properties", ({ reviewStatisticParamsWithDatableStrings }) => {
-    expect(() => v.assert(ReviewStatisticParameters, reviewStatisticParamsWithDatableStrings)).not.toThrow();
+    assertType<ReviewStatisticParameters>(reviewStatisticParamsWithDatableStrings);
   });
 });

--- a/tests/review-statistics/v20170710.test-d.ts
+++ b/tests/review-statistics/v20170710.test-d.ts
@@ -1,17 +1,10 @@
 import type {
   ReviewStatistic,
   ReviewStatisticCollection,
-  ReviewStatisticData,
   ReviewStatisticParameters,
 } from "../../src/review-statistics/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ReviewStatisticData", () => {
-  testFor("Real ReviewStatisticData", ({ reviewStatisticData }) => {
-    assertType<ReviewStatisticData>(reviewStatisticData);
-  });
-});
 
 describe("ReviewStatistic", () => {
   testFor("Real ReviewStatistic", ({ reviewStatistic }) => {

--- a/tests/review-statistics/v20170710.test.ts
+++ b/tests/review-statistics/v20170710.test.ts
@@ -9,13 +9,13 @@ import { testFor } from "../fixtures/v20170710.js";
 
 describe("ReviewStatistic", () => {
   testFor("Real ReviewStatistic", ({ reviewStatistic }) => {
-    expect(() => v.parse(ReviewStatistic, reviewStatistic)).not.toThrow();
+    expect(() => v.assert(ReviewStatistic, reviewStatistic)).not.toThrow();
   });
 });
 
 describe("ReviewStatisticCollection", () => {
   testFor("Real ReviewStatisticCollection", ({ reviewStatisticCollection }) => {
-    expect(() => v.parse(ReviewStatisticCollection, reviewStatisticCollection)).not.toThrow();
+    expect(() => v.assert(ReviewStatisticCollection, reviewStatisticCollection)).not.toThrow();
   });
 });
 

--- a/tests/review-statistics/v20170710.test.ts
+++ b/tests/review-statistics/v20170710.test.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { describe, expect, test } from "vitest";
-import { DatableString } from "../../src/base/v20170710";
-import { ReviewStatisticParameters } from "../../src/review-statistics/v20170710";
+import { DatableString } from "../../src/base/v20170710.js";
+import { ReviewStatisticParameters } from "../../src/review-statistics/v20170710.js";
 
 describe("ReviewStatisticParameters", () => {
   test("Empty ReviewStatisticParameters", () => {

--- a/tests/review-statistics/v20170710.test.ts
+++ b/tests/review-statistics/v20170710.test.ts
@@ -2,17 +2,10 @@ import * as v from "valibot";
 import {
   ReviewStatistic,
   ReviewStatisticCollection,
-  ReviewStatisticData,
   ReviewStatisticParameters,
 } from "../../src/review-statistics/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ReviewStatisticData", () => {
-  testFor("Real ReviewStatisticData", ({ reviewStatisticData }) => {
-    expect(() => v.parse(ReviewStatisticData, reviewStatisticData)).not.toThrow();
-  });
-});
 
 describe("ReviewStatistic", () => {
   testFor("Real ReviewStatistic", ({ reviewStatistic }) => {

--- a/tests/reviews/v20170710.test-d.ts
+++ b/tests/reviews/v20170710.test-d.ts
@@ -1,18 +1,6 @@
-import type {
-  Review,
-  ReviewCollection,
-  ReviewData,
-  ReviewParameters,
-  ReviewPayload,
-} from "../../src/reviews/v20170710.js";
+import type { Review, ReviewCollection, ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ReviewData", () => {
-  testFor("ReviewData from WaniKani API Docs", ({ reviewData }) => {
-    assertType<ReviewData>(reviewData);
-  });
-});
 
 describe("Review", () => {
   testFor("Review from WaniKani API Docs", ({ review }) => {

--- a/tests/reviews/v20170710.test-d.ts
+++ b/tests/reviews/v20170710.test-d.ts
@@ -1,55 +1,60 @@
-import * as v from "valibot";
-import { Review, ReviewCollection, ReviewData, ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
-import { describe, expect } from "vitest";
+import type {
+  Review,
+  ReviewCollection,
+  ReviewData,
+  ReviewParameters,
+  ReviewPayload,
+} from "../../src/reviews/v20170710.js";
+import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("ReviewData", () => {
   testFor("ReviewData from WaniKani API Docs", ({ reviewData }) => {
-    expect(() => v.assert(ReviewData, reviewData)).not.toThrow();
+    assertType<ReviewData>(reviewData);
   });
 });
 
 describe("Review", () => {
   testFor("Review from WaniKani API Docs", ({ review }) => {
-    expect(() => v.assert(Review, review)).not.toThrow();
+    assertType<Review>(review);
   });
 });
 
 describe("ReviewCollection", () => {
   testFor("ReviewCollection from WaniKani API Docs", ({ reviewCollection }) => {
-    expect(() => v.assert(ReviewCollection, reviewCollection)).not.toThrow();
+    assertType<ReviewCollection>(reviewCollection);
   });
 });
 
 describe("ReviewParameters", () => {
   testFor("Empty ReviewParameters", ({ emptyParams }) => {
-    expect(() => v.assert(ReviewParameters, emptyParams)).not.toThrow();
+    assertType<ReviewParameters>(emptyParams);
   });
   testFor("ReviewParameters with empty arrays", ({ reviewParamsWithEmptyArrays }) => {
-    expect(() => v.assert(ReviewParameters, reviewParamsWithEmptyArrays)).not.toThrow();
+    assertType<ReviewParameters>(reviewParamsWithEmptyArrays);
   });
   testFor("ReviewParameters with many options filled", ({ reviewParamsWithManyOptions }) => {
-    expect(() => v.assert(ReviewParameters, reviewParamsWithManyOptions)).not.toThrow();
+    assertType<ReviewParameters>(reviewParamsWithManyOptions);
   });
   testFor("ReviewParameters with Date objects", ({ reviewParamsWithDates }) => {
-    expect(() => v.assert(ReviewParameters, reviewParamsWithDates)).not.toThrow();
+    assertType<ReviewParameters>(reviewParamsWithDates);
   });
   testFor("ReviewParameters with DatableString properties", ({ reviewParamsWithDatableStrings }) => {
-    expect(() => v.assert(ReviewParameters, reviewParamsWithDatableStrings)).not.toThrow();
+    assertType<ReviewParameters>(reviewParamsWithDatableStrings);
   });
 });
 
 describe("ReviewPayload", () => {
   testFor("ReviewPayload with Assignment ID and JS Date", ({ reviewPayloadWithAssignmentAndDate }) => {
-    expect(() => v.assert(ReviewPayload, reviewPayloadWithAssignmentAndDate)).not.toThrow();
+    assertType<ReviewPayload>(reviewPayloadWithAssignmentAndDate);
   });
   testFor("ReviewPayload with Assignment ID and DatableString", ({ reviewPayloadWithAssignmentAndDatableStrings }) => {
-    expect(() => v.assert(ReviewPayload, reviewPayloadWithAssignmentAndDatableStrings)).not.toThrow();
+    assertType<ReviewPayload>(reviewPayloadWithAssignmentAndDatableStrings);
   });
   testFor("ReviewPayload with Subject ID and JS Date", ({ reviewPayloadWithSubjectAndDate }) => {
-    expect(() => v.assert(ReviewPayload, reviewPayloadWithSubjectAndDate)).not.toThrow();
+    assertType<ReviewPayload>(reviewPayloadWithSubjectAndDate);
   });
   testFor("ReviewPayload with Subject ID and DatableString", ({ reviewPayloadWithSubjectAndDatableStrings }) => {
-    expect(() => v.assert(ReviewPayload, reviewPayloadWithSubjectAndDatableStrings)).not.toThrow();
+    assertType<ReviewPayload>(reviewPayloadWithSubjectAndDatableStrings);
   });
 });

--- a/tests/reviews/v20170710.test.ts
+++ b/tests/reviews/v20170710.test.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { describe, expect, test } from "vitest";
-import { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710";
-import { DatableString } from "../../src/base/v20170710";
+import { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
+import { DatableString } from "../../src/base/v20170710.js";
 
 describe("ReviewParameters", () => {
   test("Empty ReviewParameters", () => {

--- a/tests/reviews/v20170710.test.ts
+++ b/tests/reviews/v20170710.test.ts
@@ -1,13 +1,7 @@
 import * as v from "valibot";
-import { Review, ReviewCollection, ReviewData, ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
+import { Review, ReviewCollection, ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("ReviewData", () => {
-  testFor("ReviewData from WaniKani API Docs", ({ reviewData }) => {
-    expect(() => v.assert(ReviewData, reviewData)).not.toThrow();
-  });
-});
 
 describe("Review", () => {
   testFor("Review from WaniKani API Docs", ({ review }) => {

--- a/tests/reviews/v20170710.test.ts
+++ b/tests/reviews/v20170710.test.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
-import { describe, expect, test } from "vitest";
 import { ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
+import { describe, expect, test } from "vitest";
 import { DatableString } from "../../src/base/v20170710.js";
 
 describe("ReviewParameters", () => {

--- a/tests/spaced-repetition-systems/v20170710.test-d.ts
+++ b/tests/spaced-repetition-systems/v20170710.test-d.ts
@@ -1,7 +1,6 @@
 import type {
   SpacedRepetitionSystem,
   SpacedRepetitionSystemCollection,
-  SpacedRepetitionSystemData,
   SpacedRepetitionSystemStageNumber,
 } from "../../src/spaced-repetition-systems/v20170710.js";
 import { assertType, describe } from "vitest";
@@ -16,12 +15,6 @@ describe("SpacedRepetitionSystemStageNumber", () => {
     } else {
       throw new TypeError("Expected spacedRepetitionSystemStageNumbers to be an array");
     }
-  });
-});
-
-describe("SpacedRepetitionSystemData", () => {
-  testFor("Real SpacedRepetitionSystemData", ({ spacedRepetitionSystemData }) => {
-    assertType<SpacedRepetitionSystemData>(spacedRepetitionSystemData);
   });
 });
 

--- a/tests/spaced-repetition-systems/v20170710.test-d.ts
+++ b/tests/spaced-repetition-systems/v20170710.test-d.ts
@@ -1,46 +1,38 @@
-import * as v from "valibot";
-import {
-  MAX_SRS_STAGE,
+import type {
   SpacedRepetitionSystem,
   SpacedRepetitionSystemCollection,
   SpacedRepetitionSystemData,
   SpacedRepetitionSystemStageNumber,
 } from "../../src/spaced-repetition-systems/v20170710.js";
-import { describe, expect } from "vitest";
+import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("SpacedRepetitionSystemStageNumber", () => {
-  testFor("Invalid SRS Stage Number: -1", () => {
-    expect(() => v.assert(SpacedRepetitionSystemStageNumber, -1)).toThrow();
-  });
   testFor("Valid SRS Stage Numbers", ({ spacedRepetitionSystemStageNumbers }) => {
     if (Array.isArray(spacedRepetitionSystemStageNumbers)) {
       spacedRepetitionSystemStageNumbers.forEach((stage) => {
-        expect(() => v.assert(SpacedRepetitionSystemStageNumber, stage)).not.toThrow();
+        assertType<SpacedRepetitionSystemStageNumber>(stage);
       });
     } else {
       throw new TypeError("Expected spacedRepetitionSystemStageNumbers to be an array");
     }
   });
-  testFor(`Invalid SRS Stage Number: ${MAX_SRS_STAGE + 1}`, () => {
-    expect(() => v.assert(SpacedRepetitionSystemStageNumber, MAX_SRS_STAGE + 1)).toThrow();
-  });
 });
 
 describe("SpacedRepetitionSystemData", () => {
   testFor("Real SpacedRepetitionSystemData", ({ spacedRepetitionSystemData }) => {
-    expect(() => v.assert(SpacedRepetitionSystemData, spacedRepetitionSystemData)).not.toThrow();
+    assertType<SpacedRepetitionSystemData>(spacedRepetitionSystemData);
   });
 });
 
 describe("SpacedRepetitionSystem", () => {
   testFor("Real SpacedRepetitionSystem", ({ spacedRepetitionSystem }) => {
-    expect(() => v.assert(SpacedRepetitionSystem, spacedRepetitionSystem)).not.toThrow();
+    assertType<SpacedRepetitionSystem>(spacedRepetitionSystem);
   });
 });
 
 describe("SpacedRepetitionSystemCollection", () => {
   testFor("Real SpacedRepetitionSystemCollection", ({ spacedRepetitionSystemCollection }) => {
-    expect(() => v.assert(SpacedRepetitionSystemCollection, spacedRepetitionSystemCollection)).not.toThrow();
+    assertType<SpacedRepetitionSystemCollection>(spacedRepetitionSystemCollection);
   });
 });

--- a/tests/spaced-repetition-systems/v20170710.test.ts
+++ b/tests/spaced-repetition-systems/v20170710.test.ts
@@ -4,7 +4,7 @@ import {
   MAX_SRS_STAGE,
   MIN_SRS_STAGE,
   SpacedRepetitionSystemStageNumber,
-} from "../../src/spaced-repetition-systems/v20170710";
+} from "../../src/spaced-repetition-systems/v20170710.js";
 
 describe("SpacedRepetitionSystemStageNumber", () => {
   test("Invalid SRS Stage Number: -1", () => {

--- a/tests/spaced-repetition-systems/v20170710.test.ts
+++ b/tests/spaced-repetition-systems/v20170710.test.ts
@@ -1,10 +1,10 @@
 import * as v from "valibot";
-import { expect, describe, test } from "vitest";
 import {
   MAX_SRS_STAGE,
   MIN_SRS_STAGE,
   SpacedRepetitionSystemStageNumber,
 } from "../../src/spaced-repetition-systems/v20170710.js";
+import { describe, expect, test } from "vitest";
 
 describe("SpacedRepetitionSystemStageNumber", () => {
   test("Invalid SRS Stage Number: -1", () => {

--- a/tests/spaced-repetition-systems/v20170710.test.ts
+++ b/tests/spaced-repetition-systems/v20170710.test.ts
@@ -3,7 +3,6 @@ import {
   MAX_SRS_STAGE,
   SpacedRepetitionSystem,
   SpacedRepetitionSystemCollection,
-  SpacedRepetitionSystemData,
   SpacedRepetitionSystemStageNumber,
 } from "../../src/spaced-repetition-systems/v20170710.js";
 import { describe, expect } from "vitest";
@@ -24,12 +23,6 @@ describe("SpacedRepetitionSystemStageNumber", () => {
   });
   testFor(`Invalid SRS Stage Number: ${MAX_SRS_STAGE + 1}`, () => {
     expect(() => v.assert(SpacedRepetitionSystemStageNumber, MAX_SRS_STAGE + 1)).toThrow();
-  });
-});
-
-describe("SpacedRepetitionSystemData", () => {
-  testFor("Real SpacedRepetitionSystemData", ({ spacedRepetitionSystemData }) => {
-    expect(() => v.assert(SpacedRepetitionSystemData, spacedRepetitionSystemData)).not.toThrow();
   });
 });
 

--- a/tests/study-materials/v20170710.test-d.ts
+++ b/tests/study-materials/v20170710.test-d.ts
@@ -1,58 +1,57 @@
-import * as v from "valibot";
-import {
+import type {
   StudyMaterial,
   StudyMaterialCollection,
   StudyMaterialCreatePayload,
   StudyMaterialParameters,
   StudyMaterialUpdatePayload,
 } from "../../src/study-materials/v20170710.js";
-import { describe, expect } from "vitest";
+import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("StudyMaterial", () => {
   testFor("Real StudyMaterial", ({ studyMaterial }) => {
-    expect(() => v.assert(StudyMaterial, studyMaterial)).not.toThrow();
+    assertType<StudyMaterial>(studyMaterial);
   });
 });
 
 describe("StudyMaterialCollection", () => {
   testFor("Real StudyMaterialCollection", ({ studyMaterialCollection }) => {
-    expect(() => v.assert(StudyMaterialCollection, studyMaterialCollection)).not.toThrow();
+    assertType<StudyMaterialCollection>(studyMaterialCollection);
   });
 });
 
 describe("StudyMaterialParameters", () => {
   testFor("Empty StudyMaterialParameters", ({ emptyParams }) => {
-    expect(() => v.assert(StudyMaterialParameters, emptyParams)).not.toThrow();
+    assertType<StudyMaterialParameters>(emptyParams);
   });
   testFor("StudyMaterialParameters with empty arrays", ({ studyMaterialParamsWithEmptyArrays }) => {
-    expect(() => v.assert(StudyMaterialParameters, studyMaterialParamsWithEmptyArrays)).not.toThrow();
+    assertType<StudyMaterialParameters>(studyMaterialParamsWithEmptyArrays);
   });
   testFor("StudyMaterialParameters with many options filled", ({ studyMaterialParamsWithManyOptions }) => {
-    expect(() => v.assert(StudyMaterialParameters, studyMaterialParamsWithManyOptions)).not.toThrow();
+    assertType<StudyMaterialParameters>(studyMaterialParamsWithManyOptions);
   });
   testFor("StudyMaterialParameters with Date objects", ({ studyMaterialParamsWithDates }) => {
-    expect(() => v.assert(StudyMaterialParameters, studyMaterialParamsWithDates)).not.toThrow();
+    assertType<StudyMaterialParameters>(studyMaterialParamsWithDates);
   });
   testFor("StudyMaterialParameters with DatableString properties", ({ studyMaterialParamsWithDatableStrings }) => {
-    expect(() => v.assert(StudyMaterialParameters, studyMaterialParamsWithDatableStrings)).not.toThrow();
+    assertType<StudyMaterialParameters>(studyMaterialParamsWithDatableStrings);
   });
 });
 
 describe("StudyMaterialUpdatePayload", () => {
   testFor("Empty payload", ({ emptyStudyMaterialUpdatePayload }) => {
-    expect(() => v.assert(StudyMaterialUpdatePayload, emptyStudyMaterialUpdatePayload)).not.toThrow();
+    assertType<StudyMaterialUpdatePayload>(emptyStudyMaterialUpdatePayload);
   });
   testFor("Payload with all properties", ({ fullStudyMaterialUpdatePayload }) => {
-    expect(() => v.assert(StudyMaterialUpdatePayload, fullStudyMaterialUpdatePayload)).not.toThrow();
+    assertType<StudyMaterialUpdatePayload>(fullStudyMaterialUpdatePayload);
   });
 });
 
 describe("StudyMaterialCreatePayload", () => {
   testFor("Payload with required properties only", ({ minimalStudyMaterialCreatePayload }) => {
-    expect(() => v.assert(StudyMaterialCreatePayload, minimalStudyMaterialCreatePayload)).not.toThrow();
+    assertType<StudyMaterialCreatePayload>(minimalStudyMaterialCreatePayload);
   });
   testFor("Payload with all properties", ({ fullStudyMaterialCreatePayload }) => {
-    expect(() => v.assert(StudyMaterialCreatePayload, fullStudyMaterialCreatePayload)).not.toThrow();
+    assertType<StudyMaterialCreatePayload>(fullStudyMaterialCreatePayload);
   });
 });

--- a/tests/study-materials/v20170710.test.ts
+++ b/tests/study-materials/v20170710.test.ts
@@ -1,10 +1,10 @@
 import * as v from "valibot";
-import { describe, expect, test } from "vitest";
 import {
-  StudyMaterialParameters,
   StudyMaterialCreatePayload,
+  StudyMaterialParameters,
   StudyMaterialUpdatePayload,
 } from "../../src/study-materials/v20170710.js";
+import { describe, expect, test } from "vitest";
 import { DatableString } from "../../src/base/v20170710.js";
 
 describe("StudyMaterialParameters", () => {

--- a/tests/study-materials/v20170710.test.ts
+++ b/tests/study-materials/v20170710.test.ts
@@ -4,8 +4,8 @@ import {
   StudyMaterialParameters,
   StudyMaterialCreatePayload,
   StudyMaterialUpdatePayload,
-} from "../../src/study-materials/v20170710";
-import { DatableString } from "../../src/base/v20170710";
+} from "../../src/study-materials/v20170710.js";
+import { DatableString } from "../../src/base/v20170710.js";
 
 describe("StudyMaterialParameters", () => {
   test("Empty StudyMaterialParameters", () => {

--- a/tests/subjects/v20170710.test-d.ts
+++ b/tests/subjects/v20170710.test-d.ts
@@ -1,0 +1,93 @@
+import type {
+  KanaVocabulary,
+  KanaVocabularyCollection,
+  KanaVocabularyData,
+  Kanji,
+  KanjiCollection,
+  KanjiData,
+  Radical,
+  RadicalCollection,
+  RadicalData,
+  Subject,
+  SubjectCollection,
+  SubjectParameters,
+  Vocabulary,
+  VocabularyCollection,
+  VocabularyData,
+} from "../../src/subjects/v20170710.js";
+import { assertType, describe } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("Subject Data", () => {
+  testFor("Real RadicalData", ({ radicalData }) => {
+    assertType<RadicalData>(radicalData);
+  });
+  testFor("Real KanjiData", ({ kanjiData }) => {
+    assertType<KanjiData>(kanjiData);
+  });
+  testFor("Real VocabularyData", ({ vocabularyData }) => {
+    assertType<VocabularyData>(vocabularyData);
+  });
+  testFor("Real KanaVocabularyData", ({ kanaVocabularyData }) => {
+    assertType<KanaVocabularyData>(kanaVocabularyData);
+  });
+});
+
+describe("Subjects", () => {
+  testFor("Real Radical", ({ radical }) => {
+    assertType<Radical>(radical);
+    assertType<Subject>(radical);
+  });
+  testFor("Real Kanji", ({ kanji }) => {
+    assertType<Kanji>(kanji);
+    assertType<Subject>(kanji);
+  });
+  testFor("Real Vocabulary", ({ vocabulary }) => {
+    assertType<Vocabulary>(vocabulary);
+    assertType<Subject>(vocabulary);
+  });
+  testFor("Real KanaVocabulary", ({ kanaVocabulary }) => {
+    assertType<KanaVocabulary>(kanaVocabulary);
+    assertType<Subject>(kanaVocabulary);
+  });
+});
+
+describe("Subject Collections", () => {
+  testFor("Real RadicalCollection", ({ radicalCollection }) => {
+    assertType<RadicalCollection>(radicalCollection);
+    assertType<SubjectCollection>(radicalCollection);
+  });
+  testFor("Real KanjiCollection", ({ kanjiCollection }) => {
+    assertType<KanjiCollection>(kanjiCollection);
+    assertType<SubjectCollection>(kanjiCollection);
+  });
+  testFor("Real VocabularyCollection", ({ vocabularyCollection }) => {
+    assertType<VocabularyCollection>(vocabularyCollection);
+    assertType<SubjectCollection>(vocabularyCollection);
+  });
+  testFor("Real KanaVocabularyCollection", ({ kanaVocabularyCollection }) => {
+    assertType<KanaVocabularyCollection>(kanaVocabularyCollection);
+    assertType<SubjectCollection>(kanaVocabularyCollection);
+  });
+  testFor("Real SubjectCollection", ({ subjectCollection }) => {
+    assertType<SubjectCollection>(subjectCollection);
+  });
+});
+
+describe("SubjectParameters", () => {
+  testFor("Empty SubjectParameters", ({ emptyParams }) => {
+    assertType<SubjectParameters>(emptyParams);
+  });
+  testFor("SubjectParameters with empty arrays", ({ subjectParamsWithEmptyArrays }) => {
+    assertType<SubjectParameters>(subjectParamsWithEmptyArrays);
+  });
+  testFor("SubjectParameters with many options filled", ({ subjectParamsWithManyOptions }) => {
+    assertType<SubjectParameters>(subjectParamsWithManyOptions);
+  });
+  testFor("SubjectParameters with Date objects", ({ subjectParamsWithDates }) => {
+    assertType<SubjectParameters>(subjectParamsWithDates);
+  });
+  testFor("SubjectParameters with DatableString properties", ({ subjectParamsWithDatableStrings }) => {
+    assertType<SubjectParameters>(subjectParamsWithDatableStrings);
+  });
+});

--- a/tests/subjects/v20170710.test-d.ts
+++ b/tests/subjects/v20170710.test-d.ts
@@ -1,37 +1,18 @@
 import type {
   KanaVocabulary,
   KanaVocabularyCollection,
-  KanaVocabularyData,
   Kanji,
   KanjiCollection,
-  KanjiData,
   Radical,
   RadicalCollection,
-  RadicalData,
   Subject,
   SubjectCollection,
   SubjectParameters,
   Vocabulary,
   VocabularyCollection,
-  VocabularyData,
 } from "../../src/subjects/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("Subject Data", () => {
-  testFor("Real RadicalData", ({ radicalData }) => {
-    assertType<RadicalData>(radicalData);
-  });
-  testFor("Real KanjiData", ({ kanjiData }) => {
-    assertType<KanjiData>(kanjiData);
-  });
-  testFor("Real VocabularyData", ({ vocabularyData }) => {
-    assertType<VocabularyData>(vocabularyData);
-  });
-  testFor("Real KanaVocabularyData", ({ kanaVocabularyData }) => {
-    assertType<KanaVocabularyData>(kanaVocabularyData);
-  });
-});
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -2,38 +2,19 @@ import * as v from "valibot";
 import {
   KanaVocabulary,
   KanaVocabularyCollection,
-  KanaVocabularyData,
   Kanji,
   KanjiCollection,
-  KanjiData,
   Radical,
   RadicalCollection,
-  RadicalData,
   Subject,
   SubjectCollection,
   SubjectParameters,
   Vocabulary,
   VocabularyCollection,
-  VocabularyData,
   WK_SUBJECT_MARKUP_MATCHERS,
 } from "../../src/subjects/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
-
-describe("Subject Data", () => {
-  testFor("Real RadicalData", ({ radicalData }) => {
-    expect(() => v.assert(RadicalData, radicalData)).not.toThrow();
-  });
-  testFor("Real KanjiData", ({ kanjiData }) => {
-    expect(() => v.assert(KanjiData, kanjiData)).not.toThrow();
-  });
-  testFor("Real VocabularyData", ({ vocabularyData }) => {
-    expect(() => v.assert(VocabularyData, vocabularyData)).not.toThrow();
-  });
-  testFor("Real KanaVocabularyData", ({ kanaVocabularyData }) => {
-    expect(() => v.assert(KanaVocabularyData, kanaVocabularyData)).not.toThrow();
-  });
-});
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -1,6 +1,6 @@
 import * as v from "valibot";
-import { describe, expect, test } from "vitest";
 import { SubjectParameters, WK_SUBJECT_MARKUP_MATCHERS } from "../../src/subjects/v20170710.js";
+import { describe, expect, test } from "vitest";
 import { DatableString } from "../../src/base/v20170710.js";
 
 describe("SubjectParameters", () => {

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -47,59 +47,59 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     const testString = `The romaji "ka" can be written as <ja>か</ja> in hiragana. The romaji "setsu" can be written as <ja>せつ</ja>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.ja)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<ja>か</ja>");
-    expect(matchedText[0].groups?.innerText).toBe("か");
-    expect(matchedText[1][0]).toBe("<ja>せつ</ja>");
-    expect(matchedText[1].groups?.innerText).toBe("せつ");
+    expect(matchedText[0]?.[0]).toBe("<ja>か</ja>");
+    expect(matchedText[0]?.groups?.innerText).toBe("か");
+    expect(matchedText[1]?.[0]).toBe("<ja>せつ</ja>");
+    expect(matchedText[1]?.groups?.innerText).toBe("せつ");
   });
 
   test("Matches Kanji highlighting in <kanji> tags", () => {
     const testString = `Two of WaniKani's Level 1 Kanji are <kanji>山</kanji> and <kanji>人</kanji>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.kanji)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<kanji>山</kanji>");
-    expect(matchedText[0].groups?.innerText).toBe("山");
-    expect(matchedText[1][0]).toBe("<kanji>人</kanji>");
-    expect(matchedText[1].groups?.innerText).toBe("人");
+    expect(matchedText[0]?.[0]).toBe("<kanji>山</kanji>");
+    expect(matchedText[0]?.groups?.innerText).toBe("山");
+    expect(matchedText[1]?.[0]).toBe("<kanji>人</kanji>");
+    expect(matchedText[1]?.groups?.innerText).toBe("人");
   });
 
   test("Matches Meaning highlighting in <meaning> tags", () => {
     const testString = `The kanji 一 means <meaning>one</meaning>. The kanji 二 means <meaning>two</meaning>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.meaning)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<meaning>one</meaning>");
-    expect(matchedText[0].groups?.innerText).toBe("one");
-    expect(matchedText[1][0]).toBe("<meaning>two</meaning>");
-    expect(matchedText[1].groups?.innerText).toBe("two");
+    expect(matchedText[0]?.[0]).toBe("<meaning>one</meaning>");
+    expect(matchedText[0]?.groups?.innerText).toBe("one");
+    expect(matchedText[1]?.[0]).toBe("<meaning>two</meaning>");
+    expect(matchedText[1]?.groups?.innerText).toBe("two");
   });
 
   test("Matches Radical highlighting in <radical> tags", () => {
     const testString = `One of the first radicals is the <radical>ground</radical> radical. A more complex one is <radical>coat rack</radical>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.radical)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<radical>ground</radical>");
-    expect(matchedText[0].groups?.innerText).toBe("ground");
-    expect(matchedText[1][0]).toBe("<radical>coat rack</radical>");
-    expect(matchedText[1].groups?.innerText).toBe("coat rack");
+    expect(matchedText[0]?.[0]).toBe("<radical>ground</radical>");
+    expect(matchedText[0]?.groups?.innerText).toBe("ground");
+    expect(matchedText[1]?.[0]).toBe("<radical>coat rack</radical>");
+    expect(matchedText[1]?.groups?.innerText).toBe("coat rack");
   });
 
   test("Matches Reading highlighting in <reading> tags", () => {
     const testString = `The partical は can sound like <reading>ha</reading>, but is also read like <reading>wa</reading>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.reading)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<reading>ha</reading>");
-    expect(matchedText[0].groups?.innerText).toBe("ha");
-    expect(matchedText[1][0]).toBe("<reading>wa</reading>");
-    expect(matchedText[1].groups?.innerText).toBe("wa");
+    expect(matchedText[0]?.[0]).toBe("<reading>ha</reading>");
+    expect(matchedText[0]?.groups?.innerText).toBe("ha");
+    expect(matchedText[1]?.[0]).toBe("<reading>wa</reading>");
+    expect(matchedText[1]?.groups?.innerText).toBe("wa");
   });
 
   test("Matches Vocabulary highlighting in <vocabulary> tags", () => {
     const testString = `The kanji 一 is used in the vocabulary <vocabulary>one thing</vocabulary> and <vocabulary>first floor</vocabulary>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
     expect(matchedText).toHaveLength(2);
-    expect(matchedText[0][0]).toBe("<vocabulary>one thing</vocabulary>");
-    expect(matchedText[0].groups?.innerText).toBe("one thing");
-    expect(matchedText[1][0]).toBe("<vocabulary>first floor</vocabulary>");
-    expect(matchedText[1].groups?.innerText).toBe("first floor");
+    expect(matchedText[0]?.[0]).toBe("<vocabulary>one thing</vocabulary>");
+    expect(matchedText[0]?.groups?.innerText).toBe("one thing");
+    expect(matchedText[1]?.[0]).toBe("<vocabulary>first floor</vocabulary>");
+    expect(matchedText[1]?.groups?.innerText).toBe("first floor");
   });
 });

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -1,49 +1,101 @@
 import * as v from "valibot";
-import { SubjectParameters, WK_SUBJECT_MARKUP_MATCHERS } from "../../src/subjects/v20170710.js";
-import { describe, expect, test } from "vitest";
-import { DatableString } from "../../src/base/v20170710.js";
+import {
+  KanaVocabulary,
+  KanaVocabularyCollection,
+  KanaVocabularyData,
+  Kanji,
+  KanjiCollection,
+  KanjiData,
+  Radical,
+  RadicalCollection,
+  RadicalData,
+  Subject,
+  SubjectCollection,
+  SubjectParameters,
+  Vocabulary,
+  VocabularyCollection,
+  VocabularyData,
+  WK_SUBJECT_MARKUP_MATCHERS,
+} from "../../src/subjects/v20170710.js";
+import { describe, expect } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("Subject Data", () => {
+  testFor("Real RadicalData", ({ radicalData }) => {
+    expect(() => v.assert(RadicalData, radicalData)).not.toThrow();
+  });
+  testFor("Real KanjiData", ({ kanjiData }) => {
+    expect(() => v.assert(KanjiData, kanjiData)).not.toThrow();
+  });
+  testFor("Real VocabularyData", ({ vocabularyData }) => {
+    expect(() => v.assert(VocabularyData, vocabularyData)).not.toThrow();
+  });
+  testFor("Real KanaVocabularyData", ({ kanaVocabularyData }) => {
+    expect(() => v.assert(KanaVocabularyData, kanaVocabularyData)).not.toThrow();
+  });
+});
+
+describe("Subjects", () => {
+  testFor("Real Radical", ({ radical }) => {
+    expect(() => v.assert(Radical, radical)).not.toThrow();
+    expect(() => v.assert(Subject, radical)).not.toThrow();
+  });
+  testFor("Real Kanji", ({ kanji }) => {
+    expect(() => v.assert(Kanji, kanji)).not.toThrow();
+    expect(() => v.assert(Subject, kanji)).not.toThrow();
+  });
+  testFor("Real Vocabulary", ({ vocabulary }) => {
+    expect(() => v.assert(Vocabulary, vocabulary)).not.toThrow();
+    expect(() => v.assert(Subject, vocabulary)).not.toThrow();
+  });
+  testFor("Real KanaVocabulary", ({ kanaVocabulary }) => {
+    expect(() => v.assert(KanaVocabulary, kanaVocabulary)).not.toThrow();
+    expect(() => v.assert(Subject, kanaVocabulary)).not.toThrow();
+  });
+});
+
+describe("Subject Collections", () => {
+  testFor("Real RadicalCollection", ({ radicalCollection }) => {
+    expect(() => v.assert(RadicalCollection, radicalCollection)).not.toThrow();
+    expect(() => v.assert(SubjectCollection, radicalCollection)).not.toThrow();
+  });
+  testFor("Real KanjiCollection", ({ kanjiCollection }) => {
+    expect(() => v.assert(KanjiCollection, kanjiCollection)).not.toThrow();
+    expect(() => v.assert(SubjectCollection, kanjiCollection)).not.toThrow();
+  });
+  testFor("Real VocabularyCollection", ({ vocabularyCollection }) => {
+    expect(() => v.assert(VocabularyCollection, vocabularyCollection)).not.toThrow();
+    expect(() => v.assert(SubjectCollection, vocabularyCollection)).not.toThrow();
+  });
+  testFor("Real KanaVocabularyCollection", ({ kanaVocabularyCollection }) => {
+    expect(() => v.assert(KanaVocabularyCollection, kanaVocabularyCollection)).not.toThrow();
+    expect(() => v.assert(SubjectCollection, kanaVocabularyCollection)).not.toThrow();
+  });
+  testFor("Real SubjectCollection", ({ subjectCollection }) => {
+    expect(() => v.assert(SubjectCollection, subjectCollection)).not.toThrow();
+  });
+});
 
 describe("SubjectParameters", () => {
-  test("Empty SubjectParameters", () => {
-    const params1: SubjectParameters = {};
-    expect(() => v.parse(SubjectParameters, params1)).not.toThrow();
+  testFor("Empty SubjectParameters", ({ emptyParams }) => {
+    expect(() => v.assert(SubjectParameters, emptyParams)).not.toThrow();
   });
-  test("SubjectParameters with empty arrays", () => {
-    const params2: SubjectParameters = {
-      ids: [],
-      levels: [],
-      slugs: [],
-    };
-    expect(() => v.parse(SubjectParameters, params2)).not.toThrow();
+  testFor("SubjectParameters with empty arrays", ({ subjectParamsWithEmptyArrays }) => {
+    expect(() => v.assert(SubjectParameters, subjectParamsWithEmptyArrays)).not.toThrow();
   });
-  test("SubjectParameters with many options filled", () => {
-    const params3: SubjectParameters = {
-      ids: [1, 2, 3],
-      levels: [1, 2, 3],
-      slugs: ["one", "two", "three"],
-      types: ["radical", "kanji"],
-      hidden: false,
-      page_after_id: 1,
-      page_before_id: 1,
-    };
-    expect(() => v.parse(SubjectParameters, params3)).not.toThrow();
+  testFor("SubjectParameters with many options filled", ({ subjectParamsWithManyOptions }) => {
+    expect(() => v.assert(SubjectParameters, subjectParamsWithManyOptions)).not.toThrow();
   });
-  test("SubjectParameters with Date objects", () => {
-    const params4: SubjectParameters = {
-      updated_after: new Date(),
-    };
-    expect(() => v.parse(SubjectParameters, params4)).not.toThrow();
+  testFor("SubjectParameters with Date objects", ({ subjectParamsWithDates }) => {
+    expect(() => v.assert(SubjectParameters, subjectParamsWithDates)).not.toThrow();
   });
-  test("SubjectParameters with DatableString properties", () => {
-    const params5: SubjectParameters = {
-      updated_after: v.parse(DatableString, new Date().toISOString()),
-    };
-    expect(() => v.parse(SubjectParameters, params5)).not.toThrow();
+  testFor("SubjectParameters with DatableString properties", ({ subjectParamsWithDatableStrings }) => {
+    expect(() => v.assert(SubjectParameters, subjectParamsWithDatableStrings)).not.toThrow();
   });
 });
 
 describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
-  test("Matches Japanese text highlighting in <ja> tags", () => {
+  testFor("Matches Japanese text highlighting in <ja> tags", () => {
     const testString = `The romaji "ka" can be written as <ja>か</ja> in hiragana. The romaji "setsu" can be written as <ja>せつ</ja>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.ja)];
     expect(matchedText).toHaveLength(2);
@@ -53,7 +105,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     expect(matchedText[1]?.groups?.innerText).toBe("せつ");
   });
 
-  test("Matches Kanji highlighting in <kanji> tags", () => {
+  testFor("Matches Kanji highlighting in <kanji> tags", () => {
     const testString = `Two of WaniKani's Level 1 Kanji are <kanji>山</kanji> and <kanji>人</kanji>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.kanji)];
     expect(matchedText).toHaveLength(2);
@@ -63,7 +115,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     expect(matchedText[1]?.groups?.innerText).toBe("人");
   });
 
-  test("Matches Meaning highlighting in <meaning> tags", () => {
+  testFor("Matches Meaning highlighting in <meaning> tags", () => {
     const testString = `The kanji 一 means <meaning>one</meaning>. The kanji 二 means <meaning>two</meaning>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.meaning)];
     expect(matchedText).toHaveLength(2);
@@ -73,7 +125,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     expect(matchedText[1]?.groups?.innerText).toBe("two");
   });
 
-  test("Matches Radical highlighting in <radical> tags", () => {
+  testFor("Matches Radical highlighting in <radical> tags", () => {
     const testString = `One of the first radicals is the <radical>ground</radical> radical. A more complex one is <radical>coat rack</radical>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.radical)];
     expect(matchedText).toHaveLength(2);
@@ -83,7 +135,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     expect(matchedText[1]?.groups?.innerText).toBe("coat rack");
   });
 
-  test("Matches Reading highlighting in <reading> tags", () => {
+  testFor("Matches Reading highlighting in <reading> tags", () => {
     const testString = `The partical は can sound like <reading>ha</reading>, but is also read like <reading>wa</reading>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.reading)];
     expect(matchedText).toHaveLength(2);
@@ -93,7 +145,7 @@ describe("WK_SUBJECT_MARKUP_MATCHERS", () => {
     expect(matchedText[1]?.groups?.innerText).toBe("wa");
   });
 
-  test("Matches Vocabulary highlighting in <vocabulary> tags", () => {
+  testFor("Matches Vocabulary highlighting in <vocabulary> tags", () => {
     const testString = `The kanji 一 is used in the vocabulary <vocabulary>one thing</vocabulary> and <vocabulary>first floor</vocabulary>.`;
     const matchedText = [...testString.matchAll(WK_SUBJECT_MARKUP_MATCHERS.vocabulary)];
     expect(matchedText).toHaveLength(2);

--- a/tests/summary/v20170710.test-d.ts
+++ b/tests/summary/v20170710.test-d.ts
@@ -1,0 +1,9 @@
+import { assertType, describe } from "vitest";
+import type { Summary } from "../../src/summary/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("Summary", () => {
+  testFor("Real Summary", ({ summary }) => {
+    assertType<Summary>(summary);
+  });
+});

--- a/tests/summary/v20170710.test.ts
+++ b/tests/summary/v20170710.test.ts
@@ -1,0 +1,10 @@
+import * as v from "valibot";
+import { describe, expect } from "vitest";
+import { Summary } from "../../src/summary/v20170710.js";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("Summary", () => {
+  testFor("Real Summary", ({ summary }) => {
+    expect(() => v.assert(Summary, summary)).not.toThrow();
+  });
+});

--- a/tests/user/v20170710.test-d.ts
+++ b/tests/user/v20170710.test-d.ts
@@ -1,0 +1,30 @@
+import type { LessonBatchSizeNumber, User, UserPreferencesPayload } from "../../src/user/v20170710.js";
+import { assertType, describe } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("LessonBatchSizeNumber", () => {
+  testFor("Valid Lesson Batch Sizes", ({ lessonBatchSizeNumbers }) => {
+    if (Array.isArray(lessonBatchSizeNumbers)) {
+      lessonBatchSizeNumbers.forEach((batchSize) => {
+        assertType<LessonBatchSizeNumber>(batchSize);
+      });
+    } else {
+      throw new TypeError("Expected lessonBatchSizeNumbers to be an array");
+    }
+  });
+});
+
+describe("User", () => {
+  testFor("Real User", ({ user }) => {
+    assertType<User>(user);
+  });
+});
+
+describe("UserPreferencesPayload", () => {
+  testFor("Payload with required properties only", ({ userPayloadWithRequiredProperties }) => {
+    assertType<UserPreferencesPayload>(userPayloadWithRequiredProperties);
+  });
+  testFor("Payload with all properties", ({ userPayloadWithAllProperties }) => {
+    assertType<UserPreferencesPayload>(userPayloadWithAllProperties);
+  });
+});

--- a/tests/user/v20170710.test.ts
+++ b/tests/user/v20170710.test.ts
@@ -5,7 +5,7 @@ import {
   UserPreferencesPayload,
   MAX_LESSON_BATCH_SIZE,
   MIN_LESSON_BATCH_SIZE,
-} from "../../src/user/v20170710";
+} from "../../src/user/v20170710.js";
 
 describe("LessonBatchSizeNumber", () => {
   test("Invalid Lesson Batch Size: 2", () => {

--- a/tests/user/v20170710.test.ts
+++ b/tests/user/v20170710.test.ts
@@ -2,52 +2,41 @@ import * as v from "valibot";
 import {
   LessonBatchSizeNumber,
   MAX_LESSON_BATCH_SIZE,
-  MIN_LESSON_BATCH_SIZE,
+  User,
   UserPreferencesPayload,
 } from "../../src/user/v20170710.js";
-import { describe, expect, test } from "vitest";
+import { describe, expect } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
 
 describe("LessonBatchSizeNumber", () => {
-  test("Invalid Lesson Batch Size: 2", () => {
-    expect(() => v.parse(LessonBatchSizeNumber, 2)).toThrow();
+  testFor("Invalid Lesson Batch Size: 2", () => {
+    expect(() => v.assert(LessonBatchSizeNumber, 2)).toThrow();
   });
-  Array<number>(MAX_LESSON_BATCH_SIZE - 2)
-    .fill(MIN_LESSON_BATCH_SIZE)
-    .map((batchSize, batchSizeIdx) => batchSize + batchSizeIdx)
-    .forEach((batchSize) => {
-      test(`Valid Lesson Batch Size: ${batchSize}`, () => {
-        expect(() => v.parse(LessonBatchSizeNumber, batchSize)).not.toThrow();
+  testFor("Valid Lesson Batch Sizes", ({ lessonBatchSizeNumbers }) => {
+    if (Array.isArray(lessonBatchSizeNumbers)) {
+      lessonBatchSizeNumbers.forEach((batchSize) => {
+        expect(() => v.assert(LessonBatchSizeNumber, batchSize)).not.toThrow();
       });
-    });
-  test(`Invalid Lesson Batch Size: ${MAX_LESSON_BATCH_SIZE + 1}`, () => {
-    expect(() => v.parse(LessonBatchSizeNumber, MAX_LESSON_BATCH_SIZE + 1)).toThrow();
+    } else {
+      throw new TypeError("Expected lessonBatchSizeNumbers to be an array");
+    }
+  });
+  testFor(`Invalid Lesson Batch Size: ${MAX_LESSON_BATCH_SIZE + 1}`, () => {
+    expect(() => v.assert(LessonBatchSizeNumber, MAX_LESSON_BATCH_SIZE + 1)).toThrow();
+  });
+});
+
+describe("User", () => {
+  testFor("Real User", ({ user }) => {
+    expect(() => v.assert(User, user)).not.toThrow();
   });
 });
 
 describe("UserPreferencesPayload", () => {
-  test("Payload with required properties only", () => {
-    const payload1: UserPreferencesPayload = {
-      user: {
-        preferences: {},
-      },
-    };
-    expect(() => v.parse(UserPreferencesPayload, payload1)).not.toThrow();
+  testFor("Payload with required properties only", ({ userPayloadWithRequiredProperties }) => {
+    expect(() => v.assert(UserPreferencesPayload, userPayloadWithRequiredProperties)).not.toThrow();
   });
-  test("Payload with all properties", () => {
-    const payload2: UserPreferencesPayload = {
-      user: {
-        preferences: {
-          default_voice_actor_id: 1,
-          extra_study_autoplay_audio: false,
-          lessons_autoplay_audio: false,
-          lessons_batch_size: 10,
-          lessons_presentation_order: "ascending_level_then_subject",
-          reviews_autoplay_audio: false,
-          reviews_display_srs_indicator: true,
-          reviews_presentation_order: "shuffled",
-        },
-      },
-    };
-    expect(() => v.parse(UserPreferencesPayload, payload2)).not.toThrow();
+  testFor("Payload with all properties", ({ userPayloadWithAllProperties }) => {
+    expect(() => v.assert(UserPreferencesPayload, userPayloadWithAllProperties)).not.toThrow();
   });
 });

--- a/tests/user/v20170710.test.ts
+++ b/tests/user/v20170710.test.ts
@@ -1,11 +1,11 @@
 import * as v from "valibot";
-import { expect, describe, test } from "vitest";
 import {
   LessonBatchSizeNumber,
-  UserPreferencesPayload,
   MAX_LESSON_BATCH_SIZE,
   MIN_LESSON_BATCH_SIZE,
+  UserPreferencesPayload,
 } from "../../src/user/v20170710.js";
+import { describe, expect, test } from "vitest";
 
 describe("LessonBatchSizeNumber", () => {
   test("Invalid Lesson Batch Size: 2", () => {

--- a/tests/voice-actors/v20170710.test-d.ts
+++ b/tests/voice-actors/v20170710.test-d.ts
@@ -1,0 +1,15 @@
+import type { VoiceActor, VoiceActorCollection } from "../../src/voice-actors/v20170710.js";
+import { assertType, describe } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("VoiceActor", () => {
+  testFor("Real VoiceActor", ({ voiceActor }) => {
+    assertType<VoiceActor>(voiceActor);
+  });
+});
+
+describe("VoiceActorCollection", () => {
+  testFor("Real VoiceActorCollection", ({ voiceActorCollection }) => {
+    assertType<VoiceActorCollection>(voiceActorCollection);
+  });
+});

--- a/tests/voice-actors/v20170710.test.ts
+++ b/tests/voice-actors/v20170710.test.ts
@@ -1,0 +1,16 @@
+import * as v from "valibot";
+import { VoiceActor, VoiceActorCollection } from "../../src/voice-actors/v20170710.js";
+import { describe, expect } from "vitest";
+import { testFor } from "../fixtures/v20170710.js";
+
+describe("VoiceActor", () => {
+  testFor("Real VoiceActor", ({ voiceActor }) => {
+    expect(() => v.assert(VoiceActor, voiceActor)).not.toThrow();
+  });
+});
+
+describe("VoiceActorCollection", () => {
+  testFor("Real VoiceActorCollection", ({ voiceActorCollection }) => {
+    expect(() => v.assert(VoiceActorCollection, voiceActorCollection)).not.toThrow();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     "exactOptionalPropertyTypes": false,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src/**/*.ts", "vitest.config.ts"],
-  "exclude": ["dist/**", "tests/**", "node_modules/**"]
+  "include": ["src/**/*.ts", "tests", "vitest.config.ts"],
+  "exclude": ["dist/**", "node_modules/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     typecheck: {
       enabled: true,
     },
+    pool: "threads",
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,5 +8,8 @@ export default defineConfig({
       exclude: ["src/index.ts", "src/v20170710.ts", ...coverageConfigDefaults.exclude],
     },
     include: ["tests/**/*.{test,spec}.ts"],
+    typecheck: {
+      enabled: true,
+    },
   },
 });


### PR DESCRIPTION
# Description

This PR contains the following changes:

- Add Valibot schema that pairs with Collection, Data, Resource, and Report types / subtypes
- Reorder types to be in composition order to pair up with the schema
- Removes the `WK` prefix from types
- Removes types that were made redundant, including internal types and individual content metadata types for radicals (these will be documented in detail before v2 is released)
- Simplify some numerical types to be more performant in TypeScript, and leave their validation up to runtime using Valibot
- Changes from a broad Subject interface to a Subject type using a discriminated union to distinguish subject types
- Update runtime tests and add type-checking tests to redundantly ensure the schemas and types match up, including using real data from the WaniKani API (albeit edited to remove copyrighted material and CDN links)
- Update project settings for running faster tests, as well as linting tests

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [x] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
