### PR TITLE
Chore: Extend Schema Using `v.entriesFromObjects`

### DIFF
--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -95,24 +95,28 @@ export interface Assignment extends BaseResource {
    */
   object: "assignment";
 }
-export const Assignment = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    available_at: v.union([DatableString, v.null()]),
-    burned_at: v.union([DatableString, v.null()]),
-    created_at: DatableString,
-    hidden: v.boolean(),
-    passed_at: v.union([DatableString, v.null()]),
-    resurrected_at: v.union([DatableString, v.null()]),
-    srs_stage: SpacedRepetitionSystemStageNumber,
-    started_at: v.union([DatableString, v.null()]),
-    subject_id: v.number(),
-    subject_type: SubjectType,
-    unlocked_at: v.union([DatableString, v.null()]),
-  }),
-  id: v.number(),
-  object: v.literal("assignment"),
-});
+export const Assignment = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        available_at: v.union([DatableString, v.null()]),
+        burned_at: v.union([DatableString, v.null()]),
+        created_at: DatableString,
+        hidden: v.boolean(),
+        passed_at: v.union([DatableString, v.null()]),
+        resurrected_at: v.union([DatableString, v.null()]),
+        srs_stage: SpacedRepetitionSystemStageNumber,
+        started_at: v.union([DatableString, v.null()]),
+        subject_id: v.number(),
+        subject_type: SubjectType,
+        unlocked_at: v.union([DatableString, v.null()]),
+      }),
+      id: v.number(),
+      object: v.literal("assignment"),
+    }),
+  ]),
+);
 
 /**
  * A collection of assignments returned from the WaniKani API.
@@ -127,10 +131,14 @@ export interface AssignmentCollection extends BaseCollection {
    */
   data: Assignment[];
 }
-export const AssignmentCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Assignment),
-});
+export const AssignmentCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Assignment),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for an
@@ -212,22 +220,26 @@ export interface AssignmentParameters extends CollectionParameters {
    */
   unlocked?: boolean;
 }
-export const AssignmentParameters = v.object({
-  ...CollectionParameters.entries,
-  available_after: v.optional(v.union([DatableString, v.date()])),
-  available_before: v.optional(v.union([DatableString, v.date()])),
-  burned: v.optional(v.boolean()),
-  hidden: v.optional(v.boolean()),
-  immediately_available_for_lessons: v.optional(v.boolean()),
-  immediately_available_for_review: v.optional(v.boolean()),
-  in_review: v.optional(v.boolean()),
-  levels: v.optional(v.array(Level)),
-  srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
-  started: v.optional(v.boolean()),
-  subject_ids: v.optional(v.array(v.number())),
-  subject_types: v.optional(SubjectTuple),
-  unlocked: v.optional(v.boolean()),
-});
+export const AssignmentParameters = v.object(
+  v.entriesFromObjects([
+    CollectionParameters,
+    v.object({
+      available_after: v.optional(v.union([DatableString, v.date()])),
+      available_before: v.optional(v.union([DatableString, v.date()])),
+      burned: v.optional(v.boolean()),
+      hidden: v.optional(v.boolean()),
+      immediately_available_for_lessons: v.optional(v.boolean()),
+      immediately_available_for_review: v.optional(v.boolean()),
+      in_review: v.optional(v.boolean()),
+      levels: v.optional(v.array(Level)),
+      srs_stages: v.optional(v.array(SpacedRepetitionSystemStageNumber)),
+      started: v.optional(v.boolean()),
+      subject_ids: v.optional(v.array(v.number())),
+      subject_types: v.optional(SubjectTuple),
+      unlocked: v.optional(v.boolean()),
+    }),
+  ]),
+);
 
 /**
  * The optional payload used in the request to start a new assignment via the WaniKani API.

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -67,20 +67,24 @@ export interface LevelProgression extends BaseResource {
    */
   object: "level_progression";
 }
-export const LevelProgression = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    abandoned_at: v.union([DatableString, v.null()]),
-    completed_at: v.union([DatableString, v.null()]),
-    created_at: DatableString,
-    level: Level,
-    passed_at: v.union([DatableString, v.null()]),
-    started_at: v.union([DatableString, v.null()]),
-    unlocked_at: v.union([DatableString, v.null()]),
-  }),
-  id: v.number(),
-  object: v.literal("level_progression"),
-});
+export const LevelProgression = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        abandoned_at: v.union([DatableString, v.null()]),
+        completed_at: v.union([DatableString, v.null()]),
+        created_at: DatableString,
+        level: Level,
+        passed_at: v.union([DatableString, v.null()]),
+        started_at: v.union([DatableString, v.null()]),
+        unlocked_at: v.union([DatableString, v.null()]),
+      }),
+      id: v.number(),
+      object: v.literal("level_progression"),
+    }),
+  ]),
+);
 
 /**
  * A collection of level progressions returned from the WaniKani API.
@@ -95,10 +99,14 @@ export interface LevelProgressionCollection extends BaseCollection {
    */
   data: LevelProgression[];
 }
-export const LevelProgressionCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(LevelProgression),
-});
+export const LevelProgressionCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(LevelProgression),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Level Progression Collection.

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -47,17 +47,21 @@ export interface Reset extends BaseResource {
    */
   object: "reset";
 }
-export const Reset = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    confirmed_at: v.union([DatableString, v.null()]),
-    created_at: DatableString,
-    original_level: Level,
-    target_level: Level,
-  }),
-  id: v.number(),
-  object: v.literal("reset"),
-});
+export const Reset = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        confirmed_at: v.union([DatableString, v.null()]),
+        created_at: DatableString,
+        original_level: Level,
+        target_level: Level,
+      }),
+      id: v.number(),
+      object: v.literal("reset"),
+    }),
+  ]),
+);
 
 /**
  * A collection of resets returned from the WaniKani API.
@@ -72,10 +76,14 @@ export interface ResetCollection extends BaseCollection {
    */
   data: Reset[];
 }
-export const ResetCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Reset),
-});
+export const ResetCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Reset),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Reset Collection.

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -100,26 +100,30 @@ export interface ReviewStatistic extends BaseResource {
    */
   object: "review_statistic";
 }
-export const ReviewStatistic = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    created_at: DatableString,
-    hidden: v.boolean(),
-    meaning_correct: v.number(),
-    meaning_current_streak: v.number(),
-    meaning_incorrect: v.number(),
-    meaning_max_streak: v.number(),
-    percentage_correct: v.number(),
-    reading_correct: v.number(),
-    reading_current_streak: v.number(),
-    reading_incorrect: v.number(),
-    reading_max_streak: v.number(),
-    subject_id: v.number(),
-    subject_type: SubjectType,
-  }),
-  id: v.number(),
-  object: v.literal("review_statistic"),
-});
+export const ReviewStatistic = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        created_at: DatableString,
+        hidden: v.boolean(),
+        meaning_correct: v.number(),
+        meaning_current_streak: v.number(),
+        meaning_incorrect: v.number(),
+        meaning_max_streak: v.number(),
+        percentage_correct: v.number(),
+        reading_correct: v.number(),
+        reading_current_streak: v.number(),
+        reading_incorrect: v.number(),
+        reading_max_streak: v.number(),
+        subject_id: v.number(),
+        subject_type: SubjectType,
+      }),
+      id: v.number(),
+      object: v.literal("review_statistic"),
+    }),
+  ]),
+);
 
 /**
  * A collection of review statistics returned from the WaniKani API.
@@ -134,10 +138,14 @@ export interface ReviewStatisticCollection extends BaseCollection {
    */
   data: ReviewStatistic[];
 }
-export const ReviewStatisticCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(ReviewStatistic),
-});
+export const ReviewStatisticCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(ReviewStatistic),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Statistic Collection.
@@ -173,11 +181,15 @@ export interface ReviewStatisticParameters extends CollectionParameters {
    */
   subject_types?: SubjectTuple;
 }
-export const ReviewStatisticParameters = v.object({
-  ...CollectionParameters.entries,
-  hidden: v.optional(v.boolean()),
-  percentages_greater_than: v.optional(v.number()),
-  percentages_less_than: v.optional(v.number()),
-  subject_ids: v.optional(v.array(v.number())),
-  subject_types: v.optional(SubjectTuple),
-});
+export const ReviewStatisticParameters = v.object(
+  v.entriesFromObjects([
+    CollectionParameters,
+    v.object({
+      hidden: v.optional(v.boolean()),
+      percentages_greater_than: v.optional(v.number()),
+      percentages_less_than: v.optional(v.number()),
+      subject_ids: v.optional(v.array(v.number())),
+      subject_types: v.optional(SubjectTuple),
+    }),
+  ]),
+);

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -70,21 +70,25 @@ export interface Review extends BaseResource {
    */
   object: "review";
 }
-export const Review = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    assignment_id: v.number(),
-    created_at: DatableString,
-    ending_srs_stage: SpacedRepetitionSystemStageNumber,
-    incorrect_meaning_answers: v.number(),
-    incorrect_reading_answers: v.number(),
-    spaced_repetition_system_id: v.number(),
-    starting_srs_stage: SpacedRepetitionSystemStageNumber,
-    subject_id: v.number(),
-  }),
-  id: v.number(),
-  object: v.literal("review"),
-});
+export const Review = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        assignment_id: v.number(),
+        created_at: DatableString,
+        ending_srs_stage: SpacedRepetitionSystemStageNumber,
+        incorrect_meaning_answers: v.number(),
+        incorrect_reading_answers: v.number(),
+        spaced_repetition_system_id: v.number(),
+        starting_srs_stage: SpacedRepetitionSystemStageNumber,
+        subject_id: v.number(),
+      }),
+      id: v.number(),
+      object: v.literal("review"),
+    }),
+  ]),
+);
 
 /**
  * A collection of reviews returned from the WaniKani API.
@@ -99,10 +103,14 @@ export interface ReviewCollection extends BaseCollection {
    */
   data: Review[];
 }
-export const ReviewCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Review),
-});
+export const ReviewCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Review),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Collection.
@@ -123,11 +131,15 @@ export interface ReviewParameters extends CollectionParameters {
    */
   subject_ids?: number[];
 }
-export const ReviewParameters = v.object({
-  ...CollectionParameters.entries,
-  assignment_ids: v.optional(v.array(v.number())),
-  subject_ids: v.optional(v.array(v.number())),
-});
+export const ReviewParameters = v.object(
+  v.entriesFromObjects([
+    CollectionParameters,
+    v.object({
+      assignment_ids: v.optional(v.array(v.number())),
+      subject_ids: v.optional(v.array(v.number())),
+    }),
+  ]),
+);
 
 /**
  * The payload used in the request to create a new review via the WaniKani API.

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -126,21 +126,25 @@ export interface SpacedRepetitionSystem extends BaseResource {
    */
   object: "spaced_repetition_system";
 }
-export const SpacedRepetitionSystem = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    burning_stage_position: SpacedRepetitionSystemStageNumber,
-    created_at: DatableString,
-    description: v.string(),
-    name: v.string(),
-    passing_stage_position: SpacedRepetitionSystemStageNumber,
-    stages: v.array(SpacedRepetitionSystemStage),
-    starting_stage_position: SpacedRepetitionSystemStageNumber,
-    unlocking_stage_position: SpacedRepetitionSystemStageNumber,
-  }),
-  id: v.number(),
-  object: v.literal("spaced_repetition_system"),
-});
+export const SpacedRepetitionSystem = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        burning_stage_position: SpacedRepetitionSystemStageNumber,
+        created_at: DatableString,
+        description: v.string(),
+        name: v.string(),
+        passing_stage_position: SpacedRepetitionSystemStageNumber,
+        stages: v.array(SpacedRepetitionSystemStage),
+        starting_stage_position: SpacedRepetitionSystemStageNumber,
+        unlocking_stage_position: SpacedRepetitionSystemStageNumber,
+      }),
+      id: v.number(),
+      object: v.literal("spaced_repetition_system"),
+    }),
+  ]),
+);
 
 /**
  * A collection of Spaced Repetition Systems returned from the WaniKani API.
@@ -155,10 +159,14 @@ export interface SpacedRepetitionSystemCollection extends BaseCollection {
    */
   data: SpacedRepetitionSystem[];
 }
-export const SpacedRepetitionSystemCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(SpacedRepetitionSystem),
-});
+export const SpacedRepetitionSystemCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(SpacedRepetitionSystem),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Spaced Repetition System Collection.

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -81,20 +81,24 @@ export interface StudyMaterial extends BaseResource {
    */
   object: "study_material";
 }
-export const StudyMaterial = v.object({
-  ...BaseResource.entries,
-  data: v.intersect([
-    StudyMaterialBaseData,
+export const StudyMaterial = v.object(
+  v.entriesFromObjects([
+    BaseResource,
     v.object({
-      created_at: DatableString,
-      hidden: v.boolean(),
-      subject_id: v.number(),
-      subject_type: SubjectType,
+      data: v.intersect([
+        StudyMaterialBaseData,
+        v.object({
+          created_at: DatableString,
+          hidden: v.boolean(),
+          subject_id: v.number(),
+          subject_type: SubjectType,
+        }),
+      ]),
+      id: v.number(),
+      object: v.literal("study_material"),
     }),
   ]),
-  id: v.number(),
-  object: v.literal("study_material"),
-});
+);
 
 /**
  * A collection of study materials returned from the WaniKani API.
@@ -109,10 +113,14 @@ export interface StudyMaterialCollection extends BaseCollection {
    */
   data: StudyMaterial[];
 }
-export const StudyMaterialCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(StudyMaterial),
-});
+export const StudyMaterialCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(StudyMaterial),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Study Material Collection.
@@ -138,12 +146,16 @@ export interface StudyMaterialParameters extends CollectionParameters {
    */
   subject_types?: SubjectTuple;
 }
-export const StudyMaterialParameters = v.object({
-  ...CollectionParameters.entries,
-  hidden: v.optional(v.boolean()),
-  subject_ids: v.optional(v.array(v.number())),
-  subject_types: v.optional(SubjectTuple),
-});
+export const StudyMaterialParameters = v.object(
+  v.entriesFromObjects([
+    CollectionParameters,
+    v.object({
+      hidden: v.optional(v.boolean()),
+      subject_ids: v.optional(v.array(v.number())),
+      subject_types: v.optional(SubjectTuple),
+    }),
+  ]),
+);
 
 /**
  * The payload sent to the WaniKani API when updating study materials.
@@ -168,7 +180,11 @@ export interface StudyMaterialCreatePayload extends StudyMaterialUpdatePayload {
    */
   subject_id: number;
 }
-export const StudyMaterialCreatePayload = v.object({
-  ...StudyMaterialUpdatePayload.entries,
-  subject_id: v.number(),
-});
+export const StudyMaterialCreatePayload = v.object(
+  v.entriesFromObjects([
+    StudyMaterialUpdatePayload,
+    v.object({
+      subject_id: v.number(),
+    }),
+  ]),
+);

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -233,12 +233,16 @@ export interface RadicalData extends SubjectBaseData {
    */
   characters: string | null;
 }
-export const RadicalData = v.object({
-  ...SubjectBaseData.entries,
-  amalgamation_subject_ids: v.array(v.number()),
-  character_images: v.array(RadicalCharacterImage),
-  characters: v.union([v.string(), v.null()]),
-});
+export const RadicalData = v.object(
+  v.entriesFromObjects([
+    SubjectBaseData,
+    v.object({
+      amalgamation_subject_ids: v.array(v.number()),
+      character_images: v.array(RadicalCharacterImage),
+      characters: v.union([v.string(), v.null()]),
+    }),
+  ]),
+);
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
@@ -267,12 +271,16 @@ export interface Radical extends BaseResource {
    */
   object: "radical";
 }
-export const Radical = v.object({
-  ...BaseResource.entries,
-  data: RadicalData,
-  id: v.number(),
-  object: v.literal("radical"),
-});
+export const Radical = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: RadicalData,
+      id: v.number(),
+      object: v.literal("radical"),
+    }),
+  ]),
+);
 
 /**
  * A collection of radical subjects returned from the WaniKani API.
@@ -287,10 +295,14 @@ export interface RadicalCollection extends BaseCollection {
    */
   data: Radical[];
 }
-export const RadicalCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Radical),
-});
+export const RadicalCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Radical),
+    }),
+  ]),
+);
 
 /**
  * Information pertaining to a reading of a kanji subject.
@@ -374,17 +386,21 @@ export interface KanjiData extends SubjectBaseData {
    */
   visually_similar_subject_ids: number[];
 }
-export const KanjiData = v.object({
-  ...SubjectBaseData.entries,
-  amalgamation_subject_ids: v.array(v.number()),
-  characters: v.string(),
-  component_subject_ids: v.array(v.number()),
-  meaning_hint: v.union([v.string(), v.null()]),
-  reading_hint: v.union([v.string(), v.null()]),
-  reading_mnemonic: v.string(),
-  readings: v.array(KanjiReading),
-  visually_similar_subject_ids: v.array(v.number()),
-});
+export const KanjiData = v.object(
+  v.entriesFromObjects([
+    SubjectBaseData,
+    v.object({
+      amalgamation_subject_ids: v.array(v.number()),
+      characters: v.string(),
+      component_subject_ids: v.array(v.number()),
+      meaning_hint: v.union([v.string(), v.null()]),
+      reading_hint: v.union([v.string(), v.null()]),
+      reading_mnemonic: v.string(),
+      readings: v.array(KanjiReading),
+      visually_similar_subject_ids: v.array(v.number()),
+    }),
+  ]),
+);
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
@@ -413,12 +429,16 @@ export interface Kanji extends BaseResource {
    */
   object: "kanji";
 }
-export const Kanji = v.object({
-  ...BaseResource.entries,
-  data: KanjiData,
-  id: v.number(),
-  object: v.literal("kanji"),
-});
+export const Kanji = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: KanjiData,
+      id: v.number(),
+      object: v.literal("kanji"),
+    }),
+  ]),
+);
 
 /**
  * A collection of kanji subjects returned from the WaniKani API.
@@ -433,10 +453,14 @@ export interface KanjiCollection extends BaseCollection {
    */
   data: Kanji[];
 }
-export const KanjiCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Kanji),
-});
+export const KanjiCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Kanji),
+    }),
+  ]),
+);
 
 /**
  * Japanese context sentences for vocabulary, with a corresponding English translation.
@@ -596,16 +620,20 @@ export interface VocabularyData extends SubjectBaseData {
    */
   readings: VocabularyReading[];
 }
-export const VocabularyData = v.object({
-  ...SubjectBaseData.entries,
-  characters: v.string(),
-  component_subject_ids: v.array(v.number()),
-  context_sentences: v.array(VocabularyContextSentence),
-  parts_of_speech: v.array(v.string()),
-  pronunciation_audios: v.array(VocabularyPronunciationAudio),
-  reading_mnemonic: v.string(),
-  readings: v.array(VocabularyReading),
-});
+export const VocabularyData = v.object(
+  v.entriesFromObjects([
+    SubjectBaseData,
+    v.object({
+      characters: v.string(),
+      component_subject_ids: v.array(v.number()),
+      context_sentences: v.array(VocabularyContextSentence),
+      parts_of_speech: v.array(v.string()),
+      pronunciation_audios: v.array(VocabularyPronunciationAudio),
+      reading_mnemonic: v.string(),
+      readings: v.array(VocabularyReading),
+    }),
+  ]),
+);
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
@@ -634,12 +662,16 @@ export interface Vocabulary extends BaseResource {
    */
   object: "vocabulary";
 }
-export const Vocabulary = v.object({
-  ...BaseResource.entries,
-  data: VocabularyData,
-  id: v.number(),
-  object: v.literal("vocabulary"),
-});
+export const Vocabulary = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: VocabularyData,
+      id: v.number(),
+      object: v.literal("vocabulary"),
+    }),
+  ]),
+);
 
 /**
  * A collection of vocabulary subjects returned from the WaniKani API.
@@ -654,10 +686,14 @@ export interface VocabularyCollection extends BaseCollection {
    */
   data: Vocabulary[];
 }
-export const VocabularyCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Vocabulary),
-});
+export const VocabularyCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Vocabulary),
+    }),
+  ]),
+);
 
 /**
  * Data returned only for kana-only vocabulary subjects.
@@ -686,13 +722,17 @@ export interface KanaVocabularyData extends SubjectBaseData {
    */
   pronunciation_audios: VocabularyPronunciationAudio[];
 }
-export const KanaVocabularyData = v.object({
-  ...SubjectBaseData.entries,
-  characters: v.string(),
-  context_sentences: v.array(VocabularyContextSentence),
-  parts_of_speech: v.array(v.string()),
-  pronunciation_audios: v.array(VocabularyPronunciationAudio),
-});
+export const KanaVocabularyData = v.object(
+  v.entriesFromObjects([
+    SubjectBaseData,
+    v.object({
+      characters: v.string(),
+      context_sentences: v.array(VocabularyContextSentence),
+      parts_of_speech: v.array(v.string()),
+      pronunciation_audios: v.array(VocabularyPronunciationAudio),
+    }),
+  ]),
+);
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
@@ -721,12 +761,16 @@ export interface KanaVocabulary extends BaseResource {
    */
   object: "kana_vocabulary";
 }
-export const KanaVocabulary = v.object({
-  ...BaseResource.entries,
-  data: KanaVocabularyData,
-  id: v.number(),
-  object: v.literal("kana_vocabulary"),
-});
+export const KanaVocabulary = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: KanaVocabularyData,
+      id: v.number(),
+      object: v.literal("kana_vocabulary"),
+    }),
+  ]),
+);
 
 /**
  * A collection of kana-only vocabulary subjects returned from the WaniKani API.
@@ -741,10 +785,14 @@ export interface KanaVocabularyCollection extends BaseCollection {
    */
   data: KanaVocabulary[];
 }
-export const KanaVocabularyCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(KanaVocabulary),
-});
+export const KanaVocabularyCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(KanaVocabulary),
+    }),
+  ]),
+);
 
 /**
  * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
@@ -846,10 +894,14 @@ export interface SubjectCollection extends BaseCollection {
    */
   data: Subject[];
 }
-export const SubjectCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(Subject),
-});
+export const SubjectCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(Subject),
+    }),
+  ]),
+);
 
 /**
  * A set of regular expression literals that match to various markup patterns in a Subject's Meaning/Reading Mnemonics
@@ -919,10 +971,14 @@ export interface SubjectParameters extends CollectionParameters {
    */
   types?: SubjectTuple;
 }
-export const SubjectParameters = v.object({
-  ...CollectionParameters.entries,
-  hidden: v.optional(v.boolean()),
-  levels: v.optional(v.array(Level)),
-  slugs: v.optional(v.array(v.string())),
-  types: v.optional(SubjectTuple),
-});
+export const SubjectParameters = v.object(
+  v.entriesFromObjects([
+    CollectionParameters,
+    v.object({
+      hidden: v.optional(v.boolean()),
+      levels: v.optional(v.array(Level)),
+      slugs: v.optional(v.array(v.string())),
+      types: v.optional(SubjectTuple),
+    }),
+  ]),
+);

--- a/src/summary/v20170710.ts
+++ b/src/summary/v20170710.ts
@@ -53,11 +53,15 @@ export interface Summary extends BaseReport {
     reviews: SummaryInterval[];
   };
 }
-export const Summary = v.object({
-  ...BaseReport.entries,
-  data: v.object({
-    lessons: v.array(SummaryInterval),
-    next_reviews_at: v.union([DatableString, v.null()]),
-    reviews: v.array(SummaryInterval),
-  }),
-});
+export const Summary = v.object(
+  v.entriesFromObjects([
+    BaseReport,
+    v.object({
+      data: v.object({
+        lessons: v.array(SummaryInterval),
+        next_reviews_at: v.union([DatableString, v.null()]),
+        reviews: v.array(SummaryInterval),
+      }),
+    }),
+  ]),
+);

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -172,25 +172,29 @@ export interface User extends BaseResource {
    */
   object: "user";
 }
-export const User = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    current_vacation_started_at: v.union([DatableString, v.null()]),
-    id: v.string(),
-    level: Level,
-    preferences: UserPreferences,
-    profile_url: v.string(),
-    started_at: DatableString,
-    subscription: v.object({
-      active: v.boolean(),
-      max_level_granted: Level,
-      period_ends_at: v.union([DatableString, v.null()]),
-      type: v.picklist(["free", "lifetime", "recurring", "unknown"]),
+export const User = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        current_vacation_started_at: v.union([DatableString, v.null()]),
+        id: v.string(),
+        level: Level,
+        preferences: UserPreferences,
+        profile_url: v.string(),
+        started_at: DatableString,
+        subscription: v.object({
+          active: v.boolean(),
+          max_level_granted: Level,
+          period_ends_at: v.union([DatableString, v.null()]),
+          type: v.picklist(["free", "lifetime", "recurring", "unknown"]),
+        }),
+        username: v.string(),
+      }),
+      object: v.literal("user"),
     }),
-    username: v.string(),
-  }),
-  object: v.literal("user"),
-});
+  ]),
+);
 
 /**
  * The payload sent to the WaniKani API to update a user's preferences.

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -44,17 +44,21 @@ export interface VoiceActor extends BaseResource {
    */
   object: "voice_actor";
 }
-export const VoiceActor = v.object({
-  ...BaseResource.entries,
-  data: v.object({
-    created_at: DatableString,
-    description: v.string(),
-    gender: v.picklist(["female", "male"]),
-    name: v.string(),
-  }),
-  id: v.number(),
-  object: v.literal("voice_actor"),
-});
+export const VoiceActor = v.object(
+  v.entriesFromObjects([
+    BaseResource,
+    v.object({
+      data: v.object({
+        created_at: DatableString,
+        description: v.string(),
+        gender: v.picklist(["female", "male"]),
+        name: v.string(),
+      }),
+      id: v.number(),
+      object: v.literal("voice_actor"),
+    }),
+  ]),
+);
 
 /**
  * A collection of voice actors returned from the WaniKani API.
@@ -69,10 +73,14 @@ export interface VoiceActorCollection extends BaseCollection {
    */
   data: VoiceActor[];
 }
-export const VoiceActorCollection = v.object({
-  ...BaseCollection.entries,
-  data: v.array(VoiceActor),
-});
+export const VoiceActorCollection = v.object(
+  v.entriesFromObjects([
+    BaseCollection,
+    v.object({
+      data: v.array(VoiceActor),
+    }),
+  ]),
+);
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Voice Actor Collection.


### PR DESCRIPTION
# Description

Valibot 1.0 RC1 added an `entriesFromObjects` utility that improves schema merging, making them more tree-shakable. This PR updates any extending schema to use this new utility.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
