### PR TITLE
BREAKING: Remove Individual Subject Resources/Collections

### DIFF
--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -245,66 +245,6 @@ export const RadicalData = v.object(
 );
 
 /**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a radical.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface Radical extends BaseResource {
-  /**
-   * Data for the returned radical.
-   */
-  data: RadicalData;
-
-  /**
-   * A unique number identifying the radical.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "radical";
-}
-export const Radical = v.object(
-  v.entriesFromObjects([
-    BaseResource,
-    v.object({
-      data: RadicalData,
-      id: v.number(),
-      object: v.literal("radical"),
-    }),
-  ]),
-);
-
-/**
- * A collection of radical subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface RadicalCollection extends BaseCollection {
-  /**
-   * An array of returned radical subjects.
-   */
-  data: Radical[];
-}
-export const RadicalCollection = v.object(
-  v.entriesFromObjects([
-    BaseCollection,
-    v.object({
-      data: v.array(Radical),
-    }),
-  ]),
-);
-
-/**
  * Information pertaining to a reading of a kanji subject.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
@@ -398,66 +338,6 @@ export const KanjiData = v.object(
       reading_mnemonic: v.string(),
       readings: v.array(KanjiReading),
       visually_similar_subject_ids: v.array(v.number()),
-    }),
-  ]),
-);
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a kanji.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface Kanji extends BaseResource {
-  /**
-   * Data for the returned kanji.
-   */
-  data: KanjiData;
-
-  /**
-   * A unique number identifying the kanji.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "kanji";
-}
-export const Kanji = v.object(
-  v.entriesFromObjects([
-    BaseResource,
-    v.object({
-      data: KanjiData,
-      id: v.number(),
-      object: v.literal("kanji"),
-    }),
-  ]),
-);
-
-/**
- * A collection of kanji subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface KanjiCollection extends BaseCollection {
-  /**
-   * An array of returned kanji subjects.
-   */
-  data: Kanji[];
-}
-export const KanjiCollection = v.object(
-  v.entriesFromObjects([
-    BaseCollection,
-    v.object({
-      data: v.array(Kanji),
     }),
   ]),
 );
@@ -636,66 +516,6 @@ export const VocabularyData = v.object(
 );
 
 /**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a vocabulary subject.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface Vocabulary extends BaseResource {
-  /**
-   * Data for the returned vocabulary.
-   */
-  data: VocabularyData;
-
-  /**
-   * A unique number identifying the vocabulary.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "vocabulary";
-}
-export const Vocabulary = v.object(
-  v.entriesFromObjects([
-    BaseResource,
-    v.object({
-      data: VocabularyData,
-      id: v.number(),
-      object: v.literal("vocabulary"),
-    }),
-  ]),
-);
-
-/**
- * A collection of vocabulary subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface VocabularyCollection extends BaseCollection {
-  /**
-   * An array of returned vocabulary subjects.
-   */
-  data: Vocabulary[];
-}
-export const VocabularyCollection = v.object(
-  v.entriesFromObjects([
-    BaseCollection,
-    v.object({
-      data: v.array(Vocabulary),
-    }),
-  ]),
-);
-
-/**
  * Data returned only for kana-only vocabulary subjects.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
@@ -730,66 +550,6 @@ export const KanaVocabularyData = v.object(
       context_sentences: v.array(VocabularyContextSentence),
       parts_of_speech: v.array(v.string()),
       pronunciation_audios: v.array(VocabularyPronunciationAudio),
-    }),
-  ]),
-);
-
-/**
- * The exact structure of a subject depends on the subject type. The available subject types are `kana_vocabulary`,
- * `kanji`, `radical`, and `vocabulary`. Note that any attributes called out for the specific subject type behaves
- * differently than the common attribute of the same name.
- *
- * This type asserts the subject type is a kana-only vocabulary subject.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Resources
- * @category Subjects
- */
-export interface KanaVocabulary extends BaseResource {
-  /**
-   * Data for the returned kana-only vocabulary.
-   */
-  data: KanaVocabularyData;
-
-  /**
-   * A unique number identifying the kana-only vocabulary.
-   */
-  id: number;
-
-  /**
-   * The kind of object returned.
-   */
-  object: "kana_vocabulary";
-}
-export const KanaVocabulary = v.object(
-  v.entriesFromObjects([
-    BaseResource,
-    v.object({
-      data: KanaVocabularyData,
-      id: v.number(),
-      object: v.literal("kana_vocabulary"),
-    }),
-  ]),
-);
-
-/**
- * A collection of kana-only vocabulary subjects returned from the WaniKani API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
- * @category Collections
- * @category Subjects
- */
-export interface KanaVocabularyCollection extends BaseCollection {
-  /**
-   * An array of returned vocabulary subjects.
-   */
-  data: KanaVocabulary[];
-}
-export const KanaVocabularyCollection = v.object(
-  v.entriesFromObjects([
-    BaseCollection,
-    v.object({
-      data: v.array(KanaVocabulary),
     }),
   ]),
 );

--- a/tests/subjects/v20170710.test-d.ts
+++ b/tests/subjects/v20170710.test-d.ts
@@ -1,56 +1,36 @@
-import type {
-  KanaVocabulary,
-  KanaVocabularyCollection,
-  Kanji,
-  KanjiCollection,
-  Radical,
-  RadicalCollection,
-  Subject,
-  SubjectCollection,
-  SubjectParameters,
-  Vocabulary,
-  VocabularyCollection,
-} from "../../src/subjects/v20170710.js";
+import type { Subject, SubjectCollection, SubjectParameters } from "../../src/subjects/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {
-    assertType<Radical>(radical);
     assertType<Subject>(radical);
   });
   testFor("Real Kanji", ({ kanji }) => {
-    assertType<Kanji>(kanji);
     assertType<Subject>(kanji);
   });
   testFor("Real Vocabulary", ({ vocabulary }) => {
-    assertType<Vocabulary>(vocabulary);
     assertType<Subject>(vocabulary);
   });
-  testFor("Real KanaVocabulary", ({ kanaVocabulary }) => {
-    assertType<KanaVocabulary>(kanaVocabulary);
+  testFor("Real Kana-Only Vocabulary", ({ kanaVocabulary }) => {
     assertType<Subject>(kanaVocabulary);
   });
 });
 
 describe("Subject Collections", () => {
-  testFor("Real RadicalCollection", ({ radicalCollection }) => {
-    assertType<RadicalCollection>(radicalCollection);
+  testFor("Collection of Radicals", ({ radicalCollection }) => {
     assertType<SubjectCollection>(radicalCollection);
   });
-  testFor("Real KanjiCollection", ({ kanjiCollection }) => {
-    assertType<KanjiCollection>(kanjiCollection);
+  testFor("Collection of Kanji", ({ kanjiCollection }) => {
     assertType<SubjectCollection>(kanjiCollection);
   });
-  testFor("Real VocabularyCollection", ({ vocabularyCollection }) => {
-    assertType<VocabularyCollection>(vocabularyCollection);
+  testFor("Collection of Vocabulary", ({ vocabularyCollection }) => {
     assertType<SubjectCollection>(vocabularyCollection);
   });
-  testFor("Real KanaVocabularyCollection", ({ kanaVocabularyCollection }) => {
-    assertType<KanaVocabularyCollection>(kanaVocabularyCollection);
+  testFor("Collection of Kana-Only Vocabulary", ({ kanaVocabularyCollection }) => {
     assertType<SubjectCollection>(kanaVocabularyCollection);
   });
-  testFor("Real SubjectCollection", ({ subjectCollection }) => {
+  testFor("Collection of Mixed Subjects", ({ subjectCollection }) => {
     assertType<SubjectCollection>(subjectCollection);
   });
 });

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -1,16 +1,8 @@
 import * as v from "valibot";
 import {
-  KanaVocabulary,
-  KanaVocabularyCollection,
-  Kanji,
-  KanjiCollection,
-  Radical,
-  RadicalCollection,
   Subject,
   SubjectCollection,
   SubjectParameters,
-  Vocabulary,
-  VocabularyCollection,
   WK_SUBJECT_MARKUP_MATCHERS,
 } from "../../src/subjects/v20170710.js";
 import { describe, expect } from "vitest";
@@ -18,38 +10,30 @@ import { testFor } from "../fixtures/v20170710.js";
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {
-    expect(() => v.assert(Radical, radical)).not.toThrow();
     expect(() => v.assert(Subject, radical)).not.toThrow();
   });
   testFor("Real Kanji", ({ kanji }) => {
-    expect(() => v.assert(Kanji, kanji)).not.toThrow();
     expect(() => v.assert(Subject, kanji)).not.toThrow();
   });
   testFor("Real Vocabulary", ({ vocabulary }) => {
-    expect(() => v.assert(Vocabulary, vocabulary)).not.toThrow();
     expect(() => v.assert(Subject, vocabulary)).not.toThrow();
   });
-  testFor("Real KanaVocabulary", ({ kanaVocabulary }) => {
-    expect(() => v.assert(KanaVocabulary, kanaVocabulary)).not.toThrow();
+  testFor("Real Kana-Only Vocabulary", ({ kanaVocabulary }) => {
     expect(() => v.assert(Subject, kanaVocabulary)).not.toThrow();
   });
 });
 
 describe("Subject Collections", () => {
-  testFor("Real RadicalCollection", ({ radicalCollection }) => {
-    expect(() => v.assert(RadicalCollection, radicalCollection)).not.toThrow();
+  testFor("Collection of Radicals", ({ radicalCollection }) => {
     expect(() => v.assert(SubjectCollection, radicalCollection)).not.toThrow();
   });
-  testFor("Real KanjiCollection", ({ kanjiCollection }) => {
-    expect(() => v.assert(KanjiCollection, kanjiCollection)).not.toThrow();
+  testFor("Collection of Kanji", ({ kanjiCollection }) => {
     expect(() => v.assert(SubjectCollection, kanjiCollection)).not.toThrow();
   });
-  testFor("Real VocabularyCollection", ({ vocabularyCollection }) => {
-    expect(() => v.assert(VocabularyCollection, vocabularyCollection)).not.toThrow();
+  testFor("Collection of Vocabulary", ({ vocabularyCollection }) => {
     expect(() => v.assert(SubjectCollection, vocabularyCollection)).not.toThrow();
   });
-  testFor("Real KanaVocabularyCollection", ({ kanaVocabularyCollection }) => {
-    expect(() => v.assert(KanaVocabularyCollection, kanaVocabularyCollection)).not.toThrow();
+  testFor("Collection of Kana-Only Vocabulary", ({ kanaVocabularyCollection }) => {
     expect(() => v.assert(SubjectCollection, kanaVocabularyCollection)).not.toThrow();
   });
   testFor("Real SubjectCollection", ({ subjectCollection }) => {


### PR DESCRIPTION
# Description

This PR removes the individual Resources and Collections for particular types of Subjects, in favor of using the `Subject` type instead. Most users will want to use the `Subject` type, and use the `object` field on the returned data to distinguish the Subject types instead.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [x] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
