### PR TITLE
Chore: Move `SubjectTuple` and `SubjectType` to `subjects` definition file

### DIFF
--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -1,13 +1,6 @@
 import * as v from "valibot";
-import {
-  BaseCollection,
-  BaseResource,
-  CollectionParameters,
-  DatableString,
-  Level,
-  SubjectTuple,
-  SubjectType,
-} from "../base/v20170710.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level } from "../base/v20170710.js";
+import { SubjectTuple, SubjectType } from "../subjects/v20170710.js";
 import { SpacedRepetitionSystemStageNumber } from "../spaced-repetition-systems/v20170710.js";
 
 /**

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -49,33 +49,6 @@ export type Level = number & {};
 export const Level = v.pipe(v.number(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
 
 /**
- * The types of subjects used on WaniKani and its API.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Base
- * @category Subjects
- */
-export type SubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
-export const SubjectType = v.picklist(["kana_vocabulary", "kanji", "radical", "vocabulary"]);
-
-/**
- * A non-empty array of WaniKani subject types.
- *
- * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Base
- * @category Subjects
- */
-export type SubjectTuple = [SubjectType, ...SubjectType[]];
-export const SubjectTuple = v.pipe(
-  v.tupleWithRest([SubjectType], SubjectType),
-  v.nonEmpty(),
-  v.checkItems(
-    (item, index, array) => array.indexOf(item) === index,
-    "Duplicate Subject Type detected in Subject Tuple",
-  ),
-);
-
-/**
  * The common properties across all Resources from the WaniKani API.
  *
  * @remarks This is a partial interface; most use cases involve using a reource that extends it.

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -1,12 +1,6 @@
 import * as v from "valibot";
-import {
-  BaseCollection,
-  BaseResource,
-  CollectionParameters,
-  DatableString,
-  SubjectTuple,
-  SubjectType,
-} from "../base/v20170710.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
+import { SubjectTuple, SubjectType } from "../subjects/v20170710.js";
 
 /**
  * Review statistics summarize the activity recorded in reviews. They contain sum the number of correct and incorrect

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -1,12 +1,6 @@
 import * as v from "valibot";
-import {
-  BaseCollection,
-  BaseResource,
-  CollectionParameters,
-  DatableString,
-  SubjectTuple,
-  SubjectType,
-} from "../base/v20170710.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
+import { SubjectTuple, SubjectType } from "../subjects/v20170710.js";
 
 /**
  * Data found in all study materials whether they are being created/updated, or received from the WaniKani API.

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -1,12 +1,32 @@
 import * as v from "valibot";
-import {
-  BaseCollection,
-  BaseResource,
-  CollectionParameters,
-  DatableString,
-  Level,
-  SubjectTuple,
-} from "../base/v20170710.js";
+import { BaseCollection, BaseResource, CollectionParameters, DatableString, Level } from "../base/v20170710.js";
+
+/**
+ * The types of subjects used on WaniKani and its API.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Base
+ * @category Subjects
+ */
+export type SubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
+export const SubjectType = v.picklist(["kana_vocabulary", "kanji", "radical", "vocabulary"]);
+
+/**
+ * A non-empty array of WaniKani subject types.
+ *
+ * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
+ * @category Base
+ * @category Subjects
+ */
+export type SubjectTuple = [SubjectType, ...SubjectType[]];
+export const SubjectTuple = v.pipe(
+  v.tupleWithRest([SubjectType], SubjectType),
+  v.nonEmpty(),
+  v.checkItems(
+    (item, index, array) => array.indexOf(item) === index,
+    "Duplicate Subject Type detected in Subject Tuple",
+  ),
+);
 
 /**
  * A subject's auxilliary meanings.

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -5,7 +5,6 @@ import { BaseCollection, BaseResource, CollectionParameters, DatableString, Leve
  * The types of subjects used on WaniKani and its API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Base
  * @category Subjects
  */
 export type SubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary";
@@ -15,7 +14,6 @@ export const SubjectType = v.picklist(["kana_vocabulary", "kanji", "radical", "v
  * A non-empty array of WaniKani subject types.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
- * @category Base
  * @category Subjects
  */
 export type SubjectTuple = [SubjectType, ...SubjectType[]];

--- a/tests/base/v20170710.test-d.ts
+++ b/tests/base/v20170710.test-d.ts
@@ -4,8 +4,6 @@ import {
   type CollectionParameters,
   type DatableString,
   type Level,
-  type SubjectTuple,
-  type SubjectType,
   stringifyParameters,
 } from "../../src/base/v20170710.js";
 import { assertType, describe, expectTypeOf } from "vitest";
@@ -32,28 +30,6 @@ describe("Level", () => {
     } else {
       throw new TypeError("Expected levels to be an array");
     }
-  });
-});
-
-describe("SubjectType", () => {
-  testFor("Valid Subject Types", ({ subjectTypes }) => {
-    if (Array.isArray(subjectTypes)) {
-      subjectTypes.forEach((subject) => {
-        assertType<SubjectType>(subject);
-      });
-    } else {
-      throw new TypeError("Expected subjectTypes to be an array");
-    }
-  });
-});
-
-describe("SubjectTuple", () => {
-  // These tests are kinda redundant, but we'll leave them here for completeness' sake
-  testFor("Partial SubjectTuple is Valid", ({ partialSubjectTuple }) => {
-    assertType<SubjectTuple>(partialSubjectTuple);
-  });
-  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
-    assertType<SubjectTuple>(fullSubjectTuple);
   });
 });
 

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -6,8 +6,6 @@ import {
   Level,
   MAX_LEVEL,
   MIN_LEVEL,
-  SubjectTuple,
-  SubjectType,
   stringifyParameters,
 } from "../../src/base/v20170710.js";
 import { describe, expect } from "vitest";
@@ -48,36 +46,6 @@ describe("Level", () => {
   });
   testFor(`Invalid Level: ${MAX_LEVEL + 1}`, () => {
     expect(() => v.assert(Level, MAX_LEVEL + 1)).toThrow();
-  });
-});
-
-describe("SubjectType", () => {
-  testFor("Valid Subject Types", ({ subjectTypes }) => {
-    if (Array.isArray(subjectTypes)) {
-      subjectTypes.forEach((subject) => {
-        expect(() => v.assert(SubjectType, subject)).not.toThrow();
-      });
-    } else {
-      throw new TypeError("Expected subjectTypes to be an array");
-    }
-  });
-  testFor("Invalid Subject Type", () => {
-    expect(() => v.assert(SubjectType, "not real")).toThrow();
-  });
-});
-
-describe("SubjectTuple", () => {
-  testFor("Empty SubjectTuple throws error", ({ emptySubjectTuple }) => {
-    expect(() => v.assert(SubjectTuple, emptySubjectTuple)).toThrow();
-  });
-  testFor("Partial SubjectTuple is valid", ({ partialSubjectTuple }) => {
-    expect(() => v.assert(SubjectTuple, partialSubjectTuple)).not.toThrow();
-  });
-  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
-    expect(() => v.assert(SubjectTuple, fullSubjectTuple)).not.toThrow();
-  });
-  testFor("SubjectTuple with repeated items throws error", ({ repeatedSubjectTuple }) => {
-    expect(() => v.assert(SubjectTuple, repeatedSubjectTuple)).toThrow();
   });
 });
 

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -1,15 +1,10 @@
 import * as v from "valibot";
-import {
-  type CollectionParameters,
-  DatableString,
-  MAX_LEVEL,
-  MIN_LEVEL,
-  SubjectTuple,
-} from "../../src/base/v20170710.js";
+import { type CollectionParameters, DatableString, MAX_LEVEL, MIN_LEVEL } from "../../src/base/v20170710.js";
 import { MAX_LESSON_BATCH_SIZE, MIN_LESSON_BATCH_SIZE } from "../../src/user/v20170710.js";
 import { MAX_SRS_STAGE, MIN_SRS_STAGE } from "../../src/spaced-repetition-systems/v20170710.js";
 import { ApiRequestFactory } from "../../src/requests/v20170710.js";
-import type { StudyMaterialUpdatePayload } from "../../src/v20170710.js";
+import type { StudyMaterialUpdatePayload } from "../../src/study-materials/v20170710.js";
+import { SubjectTuple } from "../../src/subjects/v20170710.js";
 import { test } from "vitest";
 
 // Base
@@ -26,17 +21,6 @@ const dateIsoString = new Date().toISOString();
 const levels = Array<number>(MAX_LEVEL)
   .fill(MIN_LEVEL)
   .map((item, itemIdx) => item + itemIdx);
-
-const subjectTypes = ["kana_vocabulary" as const, "kanji" as const, "radical" as const, "vocabulary" as const];
-
-// @ts-expect-error -- Intentionally empty tuple needed a type and can't use unknown[] with vitest fixtures
-const emptySubjectTuple: SubjectTuple = [];
-
-const partialSubjectTuple: SubjectTuple = ["kanji"];
-
-const fullSubjectTuple: SubjectTuple = ["kana_vocabulary", "kanji", "radical", "vocabulary"];
-
-const repeatedSubjectTuple = ["kana_vocabulary", "kanji", "radical", "kanji", "vocabulary", "radical"];
 
 const emptyParams: CollectionParameters = {};
 
@@ -524,6 +508,17 @@ const fullStudyMaterialCreatePayload = {
 };
 
 // Subjects
+
+const subjectTypes = ["kana_vocabulary" as const, "kanji" as const, "radical" as const, "vocabulary" as const];
+
+// @ts-expect-error -- Intentionally empty tuple needed a type and can't use unknown[] with vitest fixtures
+const emptySubjectTuple: SubjectTuple = [];
+
+const partialSubjectTuple: SubjectTuple = ["kanji"];
+
+const fullSubjectTuple: SubjectTuple = ["kana_vocabulary", "kanji", "radical", "vocabulary"];
+
+const repeatedSubjectTuple = ["kana_vocabulary", "kanji", "radical", "kanji", "vocabulary", "radical"];
 
 const radical = {
   id: 1,
@@ -1122,11 +1117,6 @@ export const testFor = test.extend({
   dateTimeOffsetString,
   dateIsoString,
   levels,
-  subjectTypes,
-  emptySubjectTuple,
-  partialSubjectTuple,
-  fullSubjectTuple,
-  repeatedSubjectTuple,
   emptyParams,
   collectionParamsWithEmptyArrays,
   collectionParamsWithManyOptions,
@@ -1175,6 +1165,11 @@ export const testFor = test.extend({
   fullStudyMaterialUpdatePayload,
   minimalStudyMaterialCreatePayload,
   fullStudyMaterialCreatePayload,
+  subjectTypes,
+  emptySubjectTuple,
+  partialSubjectTuple,
+  fullSubjectTuple,
+  repeatedSubjectTuple,
   radical,
   kanji,
   vocabulary,

--- a/tests/subjects/v20170710.test-d.ts
+++ b/tests/subjects/v20170710.test-d.ts
@@ -1,6 +1,34 @@
-import type { Subject, SubjectCollection, SubjectParameters } from "../../src/subjects/v20170710.js";
+import type {
+  Subject,
+  SubjectCollection,
+  SubjectParameters,
+  SubjectTuple,
+  SubjectType,
+} from "../../src/subjects/v20170710.js";
 import { assertType, describe } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
+
+describe("SubjectType", () => {
+  testFor("Valid Subject Types", ({ subjectTypes }) => {
+    if (Array.isArray(subjectTypes)) {
+      subjectTypes.forEach((subject) => {
+        assertType<SubjectType>(subject);
+      });
+    } else {
+      throw new TypeError("Expected subjectTypes to be an array");
+    }
+  });
+});
+
+describe("SubjectTuple", () => {
+  // These tests are kinda redundant, but we'll leave them here for completeness' sake
+  testFor("Partial SubjectTuple is Valid", ({ partialSubjectTuple }) => {
+    assertType<SubjectTuple>(partialSubjectTuple);
+  });
+  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
+    assertType<SubjectTuple>(fullSubjectTuple);
+  });
+});
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -3,10 +3,42 @@ import {
   Subject,
   SubjectCollection,
   SubjectParameters,
+  SubjectTuple,
+  SubjectType,
   WK_SUBJECT_MARKUP_MATCHERS,
 } from "../../src/subjects/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
+
+describe("SubjectType", () => {
+  testFor("Valid Subject Types", ({ subjectTypes }) => {
+    if (Array.isArray(subjectTypes)) {
+      subjectTypes.forEach((subject) => {
+        expect(() => v.assert(SubjectType, subject)).not.toThrow();
+      });
+    } else {
+      throw new TypeError("Expected subjectTypes to be an array");
+    }
+  });
+  testFor("Invalid Subject Type", () => {
+    expect(() => v.assert(SubjectType, "not real")).toThrow();
+  });
+});
+
+describe("SubjectTuple", () => {
+  testFor("Empty SubjectTuple throws error", ({ emptySubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, emptySubjectTuple)).toThrow();
+  });
+  testFor("Partial SubjectTuple is valid", ({ partialSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, partialSubjectTuple)).not.toThrow();
+  });
+  testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, fullSubjectTuple)).not.toThrow();
+  });
+  testFor("SubjectTuple with repeated items throws error", ({ repeatedSubjectTuple }) => {
+    expect(() => v.assert(SubjectTuple, repeatedSubjectTuple)).toThrow();
+  });
+});
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {


### PR DESCRIPTION
# Description

This PR moves the `SubjectTuple` and `SubjectType` type definitions to the definition file under `subjects`. This shouldn't have any user-facing side effects.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [x] Adds/Updates Type(s) described in the WaniKani API Docs
- [x] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [x] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
