### PR TITLE
Fix: Add Integer Check to Number Schema

### DIFF
--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -46,7 +46,7 @@ export const MAX_LEVEL = 60;
  * @category Base
  */
 export type Level = number & {};
-export const Level = v.pipe(v.number(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
+export const Level = v.pipe(v.number(), v.integer(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
 
 /**
  * The common properties across all Resources from the WaniKani API.

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -30,6 +30,7 @@ export const MAX_SRS_STAGE = 9;
 export type SpacedRepetitionSystemStageNumber = number & {};
 export const SpacedRepetitionSystemStageNumber = v.pipe(
   v.number(),
+  v.integer(),
   v.minValue(MIN_SRS_STAGE),
   v.maxValue(MAX_SRS_STAGE),
 );

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -23,6 +23,7 @@ export const MAX_LESSON_BATCH_SIZE = 10;
 export type LessonBatchSizeNumber = number & {};
 export const LessonBatchSizeNumber = v.pipe(
   v.number(),
+  v.integer(),
   v.minValue(MIN_LESSON_BATCH_SIZE),
   v.maxValue(MAX_LESSON_BATCH_SIZE),
 );

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -47,6 +47,9 @@ describe("Level", () => {
   testFor(`Invalid Level: ${MAX_LEVEL + 1}`, () => {
     expect(() => v.assert(Level, MAX_LEVEL + 1)).toThrow();
   });
+  testFor("Invalid Level: Non-Integer", () => {
+    expect(() => v.assert(Level, 1.23)).toThrow();
+  });
 });
 
 describe("CollectionParameters", () => {

--- a/tests/spaced-repetition-systems/v20170710.test.ts
+++ b/tests/spaced-repetition-systems/v20170710.test.ts
@@ -24,6 +24,9 @@ describe("SpacedRepetitionSystemStageNumber", () => {
   testFor(`Invalid SRS Stage Number: ${MAX_SRS_STAGE + 1}`, () => {
     expect(() => v.assert(SpacedRepetitionSystemStageNumber, MAX_SRS_STAGE + 1)).toThrow();
   });
+  testFor("Invalid SRS Stage: Non-Integer", () => {
+    expect(() => v.assert(SpacedRepetitionSystemStageNumber, 1.23)).toThrow();
+  });
 });
 
 describe("SpacedRepetitionSystem", () => {

--- a/tests/user/v20170710.test.ts
+++ b/tests/user/v20170710.test.ts
@@ -24,6 +24,9 @@ describe("LessonBatchSizeNumber", () => {
   testFor(`Invalid Lesson Batch Size: ${MAX_LESSON_BATCH_SIZE + 1}`, () => {
     expect(() => v.assert(LessonBatchSizeNumber, MAX_LESSON_BATCH_SIZE + 1)).toThrow();
   });
+  testFor("Invalid Lesson Batch Size: Non-Integer", () => {
+    expect(() => v.assert(LessonBatchSizeNumber, 3.45)).toThrow();
+  });
 });
 
 describe("User", () => {


### PR DESCRIPTION
# Description

This PR fixes the number schema in the library to also make sure the input is a whole number, or integer. We also added tests on the schema to make sure it throws an error when given a non-integer.

# Related Issue(s) / Pull Request(s)

None

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [x] Adds/Updates constants or other variables provided by the package
- [ ] Adds/Updates Helper Functions/Type Guards provided by the package
- [ ] Updates Documentation
- [ ] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [x] Bug Fix or Other Small Changes (i.e. patch version bump)
- [ ] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
