### PR TITLE
Add Type Guards for Returned API Items

### DIFF
--- a/src/assignments/v20170710.ts
+++ b/src/assignments/v20170710.ts
@@ -112,6 +112,17 @@ export const Assignment = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Assignments
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isAssignment(value: unknown): value is Assignment {
+  return v.is(Assignment, value);
+}
+
+/**
  * A collection of assignments returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-assignments}
@@ -132,6 +143,17 @@ export const AssignmentCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Assignments
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isAssignmentCollection(value: unknown): value is AssignmentCollection {
+  return v.is(AssignmentCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for an

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -42,6 +42,7 @@ export const DatableString = v.pipe(v.string(), v.isoTimestamp(), v.brand("Datab
  *
  * @param value The string you wish to parse and validate
  * @returns A string that can be used for date filtering in the WaniKani API
+ * @category Base
  */
 export function datableString(value: string): DatableString {
   return v.parse(DatableString, value);

--- a/src/base/v20170710.ts
+++ b/src/base/v20170710.ts
@@ -19,12 +19,44 @@ export const ApiRevision = v.literal("20170710");
 export const API_REVISION: ApiRevision = "20170710";
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Base
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isApiRevision(value: unknown): value is ApiRevision {
+  return v.is(ApiRevision, value);
+}
+
+/**
  * A `string` sent to/returned from the WaniKani API that can be converted into a JavaScript `Date` object.
  *
  * @category Base
  */
 export type DatableString = v.Brand<"DatableString"> & string;
 export const DatableString = v.pipe(v.string(), v.isoTimestamp(), v.brand("DatableString"));
+
+/**
+ * Validates that a string is a well-formatted ISO-8601 dat string.
+ *
+ * @param value The string you wish to parse and validate
+ * @returns A string that can be used for date filtering in the WaniKani API
+ */
+export function datableString(value: string): DatableString {
+  return v.parse(DatableString, value);
+}
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Base
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isDatableString(value: unknown): value is DatableString {
+  return v.is(DatableString, value);
+}
 
 /**
  * The minimum level provided by WaniKani; exported for use in lieu of a Magic Number.
@@ -47,6 +79,17 @@ export const MAX_LEVEL = 60;
  */
 export type Level = number & {};
 export const Level = v.pipe(v.number(), v.integer(), v.minValue(MIN_LEVEL), v.maxValue(MAX_LEVEL));
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Base
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isLevel(value: unknown): value is Level {
+  return v.is(Level, value);
+}
 
 /**
  * The common properties across all Resources from the WaniKani API.
@@ -270,3 +313,14 @@ export const ApiError = v.object({
   code: v.number(),
   error: v.string(),
 });
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Base
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isApiError(value: unknown): value is ApiError {
+  return v.is(ApiError, value);
+}

--- a/src/level-progressions/v20170710.ts
+++ b/src/level-progressions/v20170710.ts
@@ -87,6 +87,17 @@ export const LevelProgression = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Level Progressions
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isLevelProgression(value: unknown): value is LevelProgression {
+  return v.is(LevelProgression, value);
+}
+
+/**
  * A collection of level progressions returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-level-progressions}
@@ -107,6 +118,17 @@ export const LevelProgressionCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Level Progressions
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isLevelProgressionCollection(value: unknown): value is LevelProgressionCollection {
+  return v.is(LevelProgressionCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Level Progression Collection.

--- a/src/resets/v20170710.ts
+++ b/src/resets/v20170710.ts
@@ -64,6 +64,17 @@ export const Reset = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Resets
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isReset(value: unknown): value is Reset {
+  return v.is(Reset, value);
+}
+
+/**
  * A collection of resets returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-resets}
@@ -84,6 +95,17 @@ export const ResetCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Resets
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isResetCollection(value: unknown): value is ResetCollection {
+  return v.is(ResetCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Reset Collection.

--- a/src/review-statistics/v20170710.ts
+++ b/src/review-statistics/v20170710.ts
@@ -120,6 +120,17 @@ export const ReviewStatistic = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Review Statistics
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isReviewStatistic(value: unknown): value is ReviewStatistic {
+  return v.is(ReviewStatistic, value);
+}
+
+/**
  * A collection of review statistics returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-review-statistics}
@@ -140,6 +151,17 @@ export const ReviewStatisticCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Review Statistics
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isReviewStatisticCollection(value: unknown): value is ReviewStatisticCollection {
+  return v.is(ReviewStatisticCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Statistic Collection.

--- a/src/reviews/v20170710.ts
+++ b/src/reviews/v20170710.ts
@@ -1,7 +1,7 @@
 import * as v from "valibot";
 import { BaseCollection, BaseResource, CollectionParameters, DatableString } from "../base/v20170710.js";
-import type { Assignment } from "../assignments/v20170710.js";
-import type { ReviewStatistic } from "../review-statistics/v20170710.js";
+import { Assignment } from "../assignments/v20170710.js";
+import { ReviewStatistic } from "../review-statistics/v20170710.js";
 import { SpacedRepetitionSystemStageNumber } from "../spaced-repetition-systems/v20170710.js";
 
 /**
@@ -91,6 +91,17 @@ export const Review = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Reviews
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isReview(value: unknown): value is Review {
+  return v.is(Review, value);
+}
+
+/**
  * A collection of reviews returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-reviews}
@@ -111,6 +122,17 @@ export const ReviewCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Reviews
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isReviewCollection(value: unknown): value is ReviewCollection {
+  return v.is(ReviewCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Review Collection.
@@ -238,4 +260,26 @@ export interface CreatedReview extends Review {
      */
     review_statistic: ReviewStatistic;
   };
+}
+export const CreatedReview = v.object(
+  v.entriesFromObjects([
+    Review,
+    v.object({
+      resources_updated: v.object({
+        assignment: Assignment,
+        review_statistic: ReviewStatistic,
+      }),
+    }),
+  ]),
+);
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Reviews
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isCreatedReview(value: unknown): value is CreatedReview {
+  return v.is(CreatedReview, value);
 }

--- a/src/spaced-repetition-systems/v20170710.ts
+++ b/src/spaced-repetition-systems/v20170710.ts
@@ -36,6 +36,17 @@ export const SpacedRepetitionSystemStageNumber = v.pipe(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Spaced Repetition Systems
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSpacedRepetitionSystemStageNumber(value: unknown): value is SpacedRepetitionSystemStageNumber {
+  return v.is(SpacedRepetitionSystemStageNumber, value);
+}
+
+/**
  * An individual Spaced Repetition System (SRS) Stage.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#spaced-repetition-systems}
@@ -148,6 +159,17 @@ export const SpacedRepetitionSystem = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Spaced Repetition Systems
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSpacedRepetitionSystem(value: unknown): value is SpacedRepetitionSystem {
+  return v.is(SpacedRepetitionSystem, value);
+}
+
+/**
  * A collection of Spaced Repetition Systems returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-spaced-repetition-systems}
@@ -168,6 +190,17 @@ export const SpacedRepetitionSystemCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Spaced Repetition Systems
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSpacedRepetitionSystemCollection(value: unknown): value is SpacedRepetitionSystemCollection {
+  return v.is(SpacedRepetitionSystemCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Spaced Repetition System Collection.

--- a/src/study-materials/v20170710.ts
+++ b/src/study-materials/v20170710.ts
@@ -95,6 +95,17 @@ export const StudyMaterial = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Study Materials
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isStudyMaterial(value: unknown): value is StudyMaterial {
+  return v.is(StudyMaterial, value);
+}
+
+/**
  * A collection of study materials returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-study-materials}
@@ -115,6 +126,17 @@ export const StudyMaterialCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Study Materials
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isStudyMaterialCollection(value: unknown): value is StudyMaterialCollection {
+  return v.is(StudyMaterialCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Study Material Collection.

--- a/src/subjects/v20170710.ts
+++ b/src/subjects/v20170710.ts
@@ -11,6 +11,17 @@ export type SubjectType = "kana_vocabulary" | "kanji" | "radical" | "vocabulary"
 export const SubjectType = v.picklist(["kana_vocabulary", "kanji", "radical", "vocabulary"]);
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Subjects
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSubjectType(value: unknown): value is SubjectType {
+  return v.is(SubjectType, value);
+}
+
+/**
  * A non-empty array of WaniKani subject types.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#subjects}
@@ -25,6 +36,17 @@ export const SubjectTuple = v.pipe(
     "Duplicate Subject Type detected in Subject Tuple",
   ),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Subjects
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSubjectTuple(value: unknown): value is SubjectTuple {
+  return v.is(SubjectTuple, value);
+}
 
 /**
  * A subject's auxilliary meanings.
@@ -660,6 +682,17 @@ export const Subject = v.intersect([
 ]);
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Subjects
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSubject(value: unknown): value is Subject {
+  return v.is(Subject, value);
+}
+
+/**
  * A collection of subjects of mixed or unknown types returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-subjects}
@@ -680,6 +713,17 @@ export const SubjectCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Subjects
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSubjectCollection(value: unknown): value is SubjectCollection {
+  return v.is(SubjectCollection, value);
+}
 
 /**
  * A set of regular expression literals that match to various markup patterns in a Subject's Meaning/Reading Mnemonics

--- a/src/summary/v20170710.ts
+++ b/src/summary/v20170710.ts
@@ -65,3 +65,14 @@ export const Summary = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Summary
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isSummary(value: unknown): value is Summary {
+  return v.is(Summary, value);
+}

--- a/src/user/v20170710.ts
+++ b/src/user/v20170710.ts
@@ -29,6 +29,17 @@ export const LessonBatchSizeNumber = v.pipe(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category User
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isLessonBatchSizeNumber(value: unknown): value is LessonBatchSizeNumber {
+  return v.is(LessonBatchSizeNumber, value);
+}
+
+/**
  * User settings specific to the WaniKani application.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#user}
@@ -196,6 +207,17 @@ export const User = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category User
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isUser(value: unknown): value is User {
+  return v.is(User, value);
+}
 
 /**
  * The payload sent to the WaniKani API to update a user's preferences.

--- a/src/voice-actors/v20170710.ts
+++ b/src/voice-actors/v20170710.ts
@@ -61,6 +61,17 @@ export const VoiceActor = v.object(
 );
 
 /**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Voice Actors
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isVoiceActor(value: unknown): value is VoiceActor {
+  return v.is(VoiceActor, value);
+}
+
+/**
  * A collection of voice actors returned from the WaniKani API.
  *
  * @see {@link https://docs.api.wanikani.com/20170710/#get-all-voice-actors}
@@ -81,6 +92,17 @@ export const VoiceActorCollection = v.object(
     }),
   ]),
 );
+
+/**
+ * A type guard that checks if the given value matches the type predicate.
+ *
+ * @category Voice Actors
+ * @category Type Guards
+ */
+// @__NO_SIDE_EFFECTS__
+export function isVoiceActorCollection(value: unknown): value is VoiceActorCollection {
+  return v.is(VoiceActorCollection, value);
+}
 
 /**
  * Parameters that can be passed to the WaniKani API to filter a request for a Voice Actor Collection.

--- a/tests/assignments/v20170710.test.ts
+++ b/tests/assignments/v20170710.test.ts
@@ -4,6 +4,8 @@ import {
   AssignmentCollection,
   AssignmentParameters,
   AssignmentPayload,
+  isAssignment,
+  isAssignmentCollection,
 } from "../../src/assignments/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -11,12 +13,14 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("Assignment", () => {
   testFor("Real Assignment", ({ assignment }) => {
     expect(() => v.assert(Assignment, assignment)).not.toThrow();
+    expect(isAssignment(assignment)).toBe(true);
   });
 });
 
 describe("AssignmentCollection", () => {
   testFor("Real AssignmentCollection", ({ assignmentCollection }) => {
     expect(() => v.assert(AssignmentCollection, assignmentCollection)).not.toThrow();
+    expect(isAssignmentCollection(assignmentCollection)).toBe(true);
   });
 });
 

--- a/tests/base/v20170710.test.ts
+++ b/tests/base/v20170710.test.ts
@@ -1,11 +1,17 @@
 import * as v from "valibot";
 import {
+  ApiError,
   ApiRevision,
   CollectionParameters,
   DatableString,
   Level,
   MAX_LEVEL,
   MIN_LEVEL,
+  datableString,
+  isApiError,
+  isApiRevision,
+  isDatableString,
+  isLevel,
   stringifyParameters,
 } from "../../src/base/v20170710.js";
 import { describe, expect } from "vitest";
@@ -16,29 +22,38 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("ApiRevision", () => {
   testFor("Valid WaniKani API Revision", ({ apiRevision }) => {
     expect(() => v.assert(ApiRevision, apiRevision)).not.toThrow();
+    expect(isApiRevision(apiRevision)).toBe(true);
   });
 });
 
 describe("DatableString", () => {
   testFor("Valid UTC timestamp string", ({ dateTimeUtcString }) => {
     expect(() => v.assert(DatableString, dateTimeUtcString)).not.toThrow();
+    expect(() => datableString(dateTimeUtcString)).not.toThrow();
+    expect(isDatableString(dateTimeUtcString)).toBe(true);
   });
   testFor("Valid offset timestamp string", ({ dateTimeOffsetString }) => {
     expect(() => v.assert(DatableString, dateTimeOffsetString)).not.toThrow();
+    expect(() => datableString(dateTimeOffsetString)).not.toThrow();
+    expect(isDatableString(dateTimeOffsetString)).toBe(true);
   });
   testFor("String created from Date.toISOString", ({ dateIsoString }) => {
     expect(() => v.assert(DatableString, dateIsoString)).not.toThrow();
+    expect(() => datableString(dateIsoString)).not.toThrow();
+    expect(isDatableString(dateIsoString)).toBe(true);
   });
 });
 
 describe("Level", () => {
   testFor(`Invalid Level: ${MIN_LEVEL - 1}`, () => {
     expect(() => v.assert(Level, MIN_LEVEL - 1)).toThrow();
+    expect(isLevel(MIN_LEVEL - 1)).toBe(false);
   });
   testFor("Valid Levels", ({ levels }) => {
     if (Array.isArray(levels)) {
       levels.forEach((level) => {
         expect(() => v.assert(Level, level)).not.toThrow();
+        expect(isLevel(level)).toBe(true);
       });
     } else {
       throw new TypeError("Expected levels to be an array");
@@ -46,9 +61,11 @@ describe("Level", () => {
   });
   testFor(`Invalid Level: ${MAX_LEVEL + 1}`, () => {
     expect(() => v.assert(Level, MAX_LEVEL + 1)).toThrow();
+    expect(isLevel(MAX_LEVEL + 1)).toBe(false);
   });
   testFor("Invalid Level: Non-Integer", () => {
     expect(() => v.assert(Level, 1.23)).toThrow();
+    expect(isLevel(1.23)).toBe(false);
   });
 });
 
@@ -105,9 +122,9 @@ describe("stringifyParameters", () => {
   });
 
   testFor("Properly stringifies dates", () => {
-    const datableString = v.parse(DatableString, "2022-10-31T12:00:00.000Z");
+    const dateString = v.parse(DatableString, "2022-10-31T12:00:00.000Z");
     const params: AssignmentParameters = {
-      available_after: datableString,
+      available_after: dateString,
       available_before: new Date("2021-10-31T12:00:00.000000Z"),
     };
     const expectedString = "?available_after=2022-10-31T12:00:00.000Z&available_before=2021-10-31T12:00:00.000Z";
@@ -120,5 +137,12 @@ describe("stringifyParameters", () => {
     expect(() => stringifyParameters(notAnObject)).toThrow(
       'Invalid type: Expected Object but received "not an object"',
     );
+  });
+});
+
+describe("ApiError", () => {
+  testFor("Real ApiError", ({ apiError }) => {
+    expect(() => v.assert(ApiError, apiError)).not.toThrow();
+    expect(isApiError(apiError)).toBe(true);
   });
 });

--- a/tests/fixtures/v20170710.ts
+++ b/tests/fixtures/v20170710.ts
@@ -42,6 +42,11 @@ const collectionParamsWithDatableStrings = {
   updated_after: v.parse(DatableString, new Date().toISOString()),
 };
 
+const apiError = {
+  error: "Not found",
+  code: 404,
+};
+
 // Assignments
 
 const assignment = {
@@ -345,6 +350,65 @@ const reviewPayloadWithSubjectAndDatableStrings = {
     created_at: v.parse(DatableString, new Date().toISOString()),
     incorrect_meaning_answers: 0,
     incorrect_reading_answers: 0,
+  },
+};
+
+const createdReview = {
+  id: 2880695203,
+  object: "review" as const,
+  url: "https://api.wanikani.com/v2/reviews/2880695203",
+  data_updated_at: v.parse(DatableString, "2022-10-30T19:57:42.293840Z"),
+  data: {
+    created_at: v.parse(DatableString, "2022-10-30T19:57:42.264637Z"),
+    assignment_id: 306239913,
+    subject_id: 3521,
+    spaced_repetition_system_id: 1,
+    starting_srs_stage: 1,
+    ending_srs_stage: 2,
+    incorrect_meaning_answers: 0,
+    incorrect_reading_answers: 0,
+  },
+  resources_updated: {
+    assignment: {
+      id: 306239913,
+      object: "assignment" as const,
+      url: "https://api.wanikani.com/v2/assignments/306239913",
+      data_updated_at: v.parse(DatableString, "2022-10-30T19:57:42.289791Z"),
+      data: {
+        created_at: v.parse(DatableString, "2022-09-09T01:00:41.286804Z"),
+        subject_id: 3521,
+        subject_type: "vocabulary" as const,
+        srs_stage: 2,
+        unlocked_at: v.parse(DatableString, "2022-09-09T01:00:41.282491Z"),
+        started_at: v.parse(DatableString, "2022-10-30T12:21:36.202761Z"),
+        passed_at: null,
+        burned_at: null,
+        available_at: v.parse(DatableString, "2022-10-31T03:00:00.000000Z"),
+        resurrected_at: null,
+        hidden: false,
+      },
+    },
+    review_statistic: {
+      id: 289182396,
+      object: "review_statistic" as const,
+      url: "https://api.wanikani.com/v2/review_statistics/289182396",
+      data_updated_at: v.parse(DatableString, "2022-10-30T19:57:42.300555Z"),
+      data: {
+        created_at: v.parse(DatableString, "2022-10-30T12:21:36.226528Z"),
+        subject_id: 3521,
+        subject_type: "vocabulary" as const,
+        meaning_correct: 1,
+        meaning_incorrect: 0,
+        meaning_max_streak: 1,
+        meaning_current_streak: 1,
+        reading_correct: 1,
+        reading_incorrect: 0,
+        reading_max_streak: 1,
+        reading_current_streak: 1,
+        percentage_correct: 100,
+        hidden: false,
+      },
+    },
   },
 };
 
@@ -1122,6 +1186,7 @@ export const testFor = test.extend({
   collectionParamsWithManyOptions,
   collectionParamsWithDates,
   collectionParamsWithDatableStrings,
+  apiError,
   assignment,
   assignmentCollection,
   assignmentParamsWithEmptyArrays,
@@ -1152,6 +1217,7 @@ export const testFor = test.extend({
   reviewPayloadWithAssignmentAndDatableStrings,
   reviewPayloadWithSubjectAndDate,
   reviewPayloadWithSubjectAndDatableStrings,
+  createdReview,
   spacedRepetitionSystemStageNumbers,
   spacedRepetitionSystem,
   spacedRepetitionSystemCollection,

--- a/tests/level-progressions/v20170710.test.ts
+++ b/tests/level-progressions/v20170710.test.ts
@@ -1,16 +1,23 @@
 import * as v from "valibot";
-import { LevelProgression, LevelProgressionCollection } from "../../src/level-progressions/v20170710.js";
+import {
+  LevelProgression,
+  LevelProgressionCollection,
+  isLevelProgression,
+  isLevelProgressionCollection,
+} from "../../src/level-progressions/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("LevelProgression", () => {
   testFor("Real LevelProgression", ({ levelProgression }) => {
     expect(() => v.assert(LevelProgression, levelProgression)).not.toThrow();
+    expect(isLevelProgression(levelProgression)).toBe(true);
   });
 });
 
 describe("LevelProgressionCollection", () => {
   testFor("Real LevelProgressionCollection", ({ levelProgressionCollection }) => {
     expect(() => v.assert(LevelProgressionCollection, levelProgressionCollection)).not.toThrow();
+    expect(isLevelProgressionCollection(levelProgressionCollection)).toBe(true);
   });
 });

--- a/tests/resets/v20170710.test.ts
+++ b/tests/resets/v20170710.test.ts
@@ -1,16 +1,18 @@
 import * as v from "valibot";
-import { Reset, ResetCollection } from "../../src/resets/v20170710.js";
+import { Reset, ResetCollection, isReset, isResetCollection } from "../../src/resets/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("Reset", () => {
   testFor("Real Reset", ({ reset }) => {
     expect(() => v.assert(Reset, reset)).not.toThrow();
+    expect(isReset(reset)).toBe(true);
   });
 });
 
 describe("ResetCollection", () => {
   testFor("Real ResetCollection", ({ resetCollection }) => {
     expect(() => v.assert(ResetCollection, resetCollection)).not.toThrow();
+    expect(isResetCollection(resetCollection)).toBe(true);
   });
 });

--- a/tests/review-statistics/v20170710.test.ts
+++ b/tests/review-statistics/v20170710.test.ts
@@ -3,6 +3,8 @@ import {
   ReviewStatistic,
   ReviewStatisticCollection,
   ReviewStatisticParameters,
+  isReviewStatistic,
+  isReviewStatisticCollection,
 } from "../../src/review-statistics/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -10,12 +12,14 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("ReviewStatistic", () => {
   testFor("Real ReviewStatistic", ({ reviewStatistic }) => {
     expect(() => v.assert(ReviewStatistic, reviewStatistic)).not.toThrow();
+    expect(isReviewStatistic(reviewStatistic)).toBe(true);
   });
 });
 
 describe("ReviewStatisticCollection", () => {
   testFor("Real ReviewStatisticCollection", ({ reviewStatisticCollection }) => {
     expect(() => v.assert(ReviewStatisticCollection, reviewStatisticCollection)).not.toThrow();
+    expect(isReviewStatisticCollection(reviewStatisticCollection)).toBe(true);
   });
 });
 

--- a/tests/reviews/v20170710.test.ts
+++ b/tests/reviews/v20170710.test.ts
@@ -1,17 +1,28 @@
 import * as v from "valibot";
-import { Review, ReviewCollection, ReviewParameters, ReviewPayload } from "../../src/reviews/v20170710.js";
+import {
+  CreatedReview,
+  Review,
+  ReviewCollection,
+  ReviewParameters,
+  ReviewPayload,
+  isCreatedReview,
+  isReview,
+  isReviewCollection,
+} from "../../src/reviews/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("Review", () => {
   testFor("Review from WaniKani API Docs", ({ review }) => {
     expect(() => v.assert(Review, review)).not.toThrow();
+    expect(isReview(review)).toBe(true);
   });
 });
 
 describe("ReviewCollection", () => {
   testFor("ReviewCollection from WaniKani API Docs", ({ reviewCollection }) => {
     expect(() => v.assert(ReviewCollection, reviewCollection)).not.toThrow();
+    expect(isReviewCollection(reviewCollection)).toBe(true);
   });
 });
 
@@ -45,5 +56,12 @@ describe("ReviewPayload", () => {
   });
   testFor("ReviewPayload with Subject ID and DatableString", ({ reviewPayloadWithSubjectAndDatableStrings }) => {
     expect(() => v.assert(ReviewPayload, reviewPayloadWithSubjectAndDatableStrings)).not.toThrow();
+  });
+});
+
+describe("CreatedReview", () => {
+  testFor("Real CreatedReview", ({ createdReview }) => {
+    expect(() => v.assert(CreatedReview, createdReview)).not.toThrow();
+    expect(isCreatedReview(createdReview)).toBe(true);
   });
 });

--- a/tests/spaced-repetition-systems/v20170710.test.ts
+++ b/tests/spaced-repetition-systems/v20170710.test.ts
@@ -4,6 +4,9 @@ import {
   SpacedRepetitionSystem,
   SpacedRepetitionSystemCollection,
   SpacedRepetitionSystemStageNumber,
+  isSpacedRepetitionSystem,
+  isSpacedRepetitionSystemCollection,
+  isSpacedRepetitionSystemStageNumber,
 } from "../../src/spaced-repetition-systems/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -11,11 +14,13 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("SpacedRepetitionSystemStageNumber", () => {
   testFor("Invalid SRS Stage Number: -1", () => {
     expect(() => v.assert(SpacedRepetitionSystemStageNumber, -1)).toThrow();
+    expect(isSpacedRepetitionSystemStageNumber(-1)).toBe(false);
   });
   testFor("Valid SRS Stage Numbers", ({ spacedRepetitionSystemStageNumbers }) => {
     if (Array.isArray(spacedRepetitionSystemStageNumbers)) {
       spacedRepetitionSystemStageNumbers.forEach((stage) => {
         expect(() => v.assert(SpacedRepetitionSystemStageNumber, stage)).not.toThrow();
+        expect(isSpacedRepetitionSystemStageNumber(stage)).toBe(true);
       });
     } else {
       throw new TypeError("Expected spacedRepetitionSystemStageNumbers to be an array");
@@ -23,20 +28,24 @@ describe("SpacedRepetitionSystemStageNumber", () => {
   });
   testFor(`Invalid SRS Stage Number: ${MAX_SRS_STAGE + 1}`, () => {
     expect(() => v.assert(SpacedRepetitionSystemStageNumber, MAX_SRS_STAGE + 1)).toThrow();
+    expect(isSpacedRepetitionSystemStageNumber(MAX_SRS_STAGE + 1)).toBe(false);
   });
   testFor("Invalid SRS Stage: Non-Integer", () => {
     expect(() => v.assert(SpacedRepetitionSystemStageNumber, 1.23)).toThrow();
+    expect(isSpacedRepetitionSystemStageNumber(1.23)).toBe(false);
   });
 });
 
 describe("SpacedRepetitionSystem", () => {
   testFor("Real SpacedRepetitionSystem", ({ spacedRepetitionSystem }) => {
     expect(() => v.assert(SpacedRepetitionSystem, spacedRepetitionSystem)).not.toThrow();
+    expect(isSpacedRepetitionSystem(spacedRepetitionSystem)).toBe(true);
   });
 });
 
 describe("SpacedRepetitionSystemCollection", () => {
   testFor("Real SpacedRepetitionSystemCollection", ({ spacedRepetitionSystemCollection }) => {
     expect(() => v.assert(SpacedRepetitionSystemCollection, spacedRepetitionSystemCollection)).not.toThrow();
+    expect(isSpacedRepetitionSystemCollection(spacedRepetitionSystemCollection)).toBe(true);
   });
 });

--- a/tests/study-materials/v20170710.test.ts
+++ b/tests/study-materials/v20170710.test.ts
@@ -5,6 +5,8 @@ import {
   StudyMaterialCreatePayload,
   StudyMaterialParameters,
   StudyMaterialUpdatePayload,
+  isStudyMaterial,
+  isStudyMaterialCollection,
 } from "../../src/study-materials/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -12,12 +14,14 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("StudyMaterial", () => {
   testFor("Real StudyMaterial", ({ studyMaterial }) => {
     expect(() => v.assert(StudyMaterial, studyMaterial)).not.toThrow();
+    expect(isStudyMaterial(studyMaterial)).toBe(true);
   });
 });
 
 describe("StudyMaterialCollection", () => {
   testFor("Real StudyMaterialCollection", ({ studyMaterialCollection }) => {
     expect(() => v.assert(StudyMaterialCollection, studyMaterialCollection)).not.toThrow();
+    expect(isStudyMaterialCollection(studyMaterialCollection)).toBe(true);
   });
 });
 

--- a/tests/subjects/v20170710.test.ts
+++ b/tests/subjects/v20170710.test.ts
@@ -6,6 +6,10 @@ import {
   SubjectTuple,
   SubjectType,
   WK_SUBJECT_MARKUP_MATCHERS,
+  isSubject,
+  isSubjectCollection,
+  isSubjectTuple,
+  isSubjectType,
 } from "../../src/subjects/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -15,6 +19,7 @@ describe("SubjectType", () => {
     if (Array.isArray(subjectTypes)) {
       subjectTypes.forEach((subject) => {
         expect(() => v.assert(SubjectType, subject)).not.toThrow();
+        expect(isSubjectType(subject)).toBe(true);
       });
     } else {
       throw new TypeError("Expected subjectTypes to be an array");
@@ -22,54 +27,68 @@ describe("SubjectType", () => {
   });
   testFor("Invalid Subject Type", () => {
     expect(() => v.assert(SubjectType, "not real")).toThrow();
+    expect(isSubjectType("not real")).toBe(false);
   });
 });
 
 describe("SubjectTuple", () => {
   testFor("Empty SubjectTuple throws error", ({ emptySubjectTuple }) => {
     expect(() => v.assert(SubjectTuple, emptySubjectTuple)).toThrow();
+    expect(isSubjectTuple(emptySubjectTuple)).toBe(false);
   });
   testFor("Partial SubjectTuple is valid", ({ partialSubjectTuple }) => {
     expect(() => v.assert(SubjectTuple, partialSubjectTuple)).not.toThrow();
+    expect(isSubjectTuple(partialSubjectTuple)).toBe(true);
   });
   testFor("Full SubjectTuple is valid", ({ fullSubjectTuple }) => {
     expect(() => v.assert(SubjectTuple, fullSubjectTuple)).not.toThrow();
+    expect(isSubjectTuple(fullSubjectTuple)).toBe(true);
   });
   testFor("SubjectTuple with repeated items throws error", ({ repeatedSubjectTuple }) => {
     expect(() => v.assert(SubjectTuple, repeatedSubjectTuple)).toThrow();
+    expect(isSubjectTuple(repeatedSubjectTuple)).toBe(false);
   });
 });
 
 describe("Subjects", () => {
   testFor("Real Radical", ({ radical }) => {
     expect(() => v.assert(Subject, radical)).not.toThrow();
+    expect(isSubject(radical)).toBe(true);
   });
   testFor("Real Kanji", ({ kanji }) => {
     expect(() => v.assert(Subject, kanji)).not.toThrow();
+    expect(isSubject(kanji)).toBe(true);
   });
   testFor("Real Vocabulary", ({ vocabulary }) => {
     expect(() => v.assert(Subject, vocabulary)).not.toThrow();
+    expect(isSubject(vocabulary)).toBe(true);
   });
   testFor("Real Kana-Only Vocabulary", ({ kanaVocabulary }) => {
     expect(() => v.assert(Subject, kanaVocabulary)).not.toThrow();
+    expect(isSubject(kanaVocabulary)).toBe(true);
   });
 });
 
 describe("Subject Collections", () => {
   testFor("Collection of Radicals", ({ radicalCollection }) => {
     expect(() => v.assert(SubjectCollection, radicalCollection)).not.toThrow();
+    expect(isSubjectCollection(radicalCollection)).toBe(true);
   });
   testFor("Collection of Kanji", ({ kanjiCollection }) => {
     expect(() => v.assert(SubjectCollection, kanjiCollection)).not.toThrow();
+    expect(isSubjectCollection(kanjiCollection)).toBe(true);
   });
   testFor("Collection of Vocabulary", ({ vocabularyCollection }) => {
     expect(() => v.assert(SubjectCollection, vocabularyCollection)).not.toThrow();
+    expect(isSubjectCollection(vocabularyCollection)).toBe(true);
   });
   testFor("Collection of Kana-Only Vocabulary", ({ kanaVocabularyCollection }) => {
     expect(() => v.assert(SubjectCollection, kanaVocabularyCollection)).not.toThrow();
+    expect(isSubjectCollection(kanaVocabularyCollection)).toBe(true);
   });
   testFor("Real SubjectCollection", ({ subjectCollection }) => {
     expect(() => v.assert(SubjectCollection, subjectCollection)).not.toThrow();
+    expect(isSubjectCollection(subjectCollection)).toBe(true);
   });
 });
 

--- a/tests/summary/v20170710.test.ts
+++ b/tests/summary/v20170710.test.ts
@@ -1,10 +1,11 @@
 import * as v from "valibot";
+import { Summary, isSummary } from "../../src/summary/v20170710.js";
 import { describe, expect } from "vitest";
-import { Summary } from "../../src/summary/v20170710.js";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("Summary", () => {
   testFor("Real Summary", ({ summary }) => {
     expect(() => v.assert(Summary, summary)).not.toThrow();
+    expect(isSummary(summary)).toBe(true);
   });
 });

--- a/tests/user/v20170710.test.ts
+++ b/tests/user/v20170710.test.ts
@@ -4,6 +4,8 @@ import {
   MAX_LESSON_BATCH_SIZE,
   User,
   UserPreferencesPayload,
+  isLessonBatchSizeNumber,
+  isUser,
 } from "../../src/user/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
@@ -11,11 +13,13 @@ import { testFor } from "../fixtures/v20170710.js";
 describe("LessonBatchSizeNumber", () => {
   testFor("Invalid Lesson Batch Size: 2", () => {
     expect(() => v.assert(LessonBatchSizeNumber, 2)).toThrow();
+    expect(isLessonBatchSizeNumber(2)).toBe(false);
   });
   testFor("Valid Lesson Batch Sizes", ({ lessonBatchSizeNumbers }) => {
     if (Array.isArray(lessonBatchSizeNumbers)) {
       lessonBatchSizeNumbers.forEach((batchSize) => {
         expect(() => v.assert(LessonBatchSizeNumber, batchSize)).not.toThrow();
+        expect(isLessonBatchSizeNumber(batchSize)).toBe(true);
       });
     } else {
       throw new TypeError("Expected lessonBatchSizeNumbers to be an array");
@@ -23,15 +27,18 @@ describe("LessonBatchSizeNumber", () => {
   });
   testFor(`Invalid Lesson Batch Size: ${MAX_LESSON_BATCH_SIZE + 1}`, () => {
     expect(() => v.assert(LessonBatchSizeNumber, MAX_LESSON_BATCH_SIZE + 1)).toThrow();
+    expect(isLessonBatchSizeNumber(MAX_LESSON_BATCH_SIZE + 1)).toBe(false);
   });
   testFor("Invalid Lesson Batch Size: Non-Integer", () => {
     expect(() => v.assert(LessonBatchSizeNumber, 3.45)).toThrow();
+    expect(isLessonBatchSizeNumber(3.45)).toBe(false);
   });
 });
 
 describe("User", () => {
   testFor("Real User", ({ user }) => {
     expect(() => v.assert(User, user)).not.toThrow();
+    expect(isUser(user)).toBe(true);
   });
 });
 

--- a/tests/voice-actors/v20170710.test.ts
+++ b/tests/voice-actors/v20170710.test.ts
@@ -1,16 +1,23 @@
 import * as v from "valibot";
-import { VoiceActor, VoiceActorCollection } from "../../src/voice-actors/v20170710.js";
+import {
+  VoiceActor,
+  VoiceActorCollection,
+  isVoiceActor,
+  isVoiceActorCollection,
+} from "../../src/voice-actors/v20170710.js";
 import { describe, expect } from "vitest";
 import { testFor } from "../fixtures/v20170710.js";
 
 describe("VoiceActor", () => {
   testFor("Real VoiceActor", ({ voiceActor }) => {
     expect(() => v.assert(VoiceActor, voiceActor)).not.toThrow();
+    expect(isVoiceActor(voiceActor)).toBe(true);
   });
 });
 
 describe("VoiceActorCollection", () => {
   testFor("Real VoiceActorCollection", ({ voiceActorCollection }) => {
     expect(() => v.assert(VoiceActorCollection, voiceActorCollection)).not.toThrow();
+    expect(isVoiceActorCollection(voiceActorCollection)).toBe(true);
   });
 });

--- a/typedoc.json
+++ b/typedoc.json
@@ -7,7 +7,17 @@
   "cleanOutputDir": true,
   "includeVersion": true,
   "categorizeByGroup": false,
-  "categoryOrder": ["Base", "Collections", "Parameters", "Payloads", "Reports", "Requests", "Resources", "*"],
+  "categoryOrder": [
+    "Base",
+    "Collections",
+    "Parameters",
+    "Payloads",
+    "Reports",
+    "Requests",
+    "Resources",
+    "Type Guards",
+    "*"
+  ],
   "navigation": {
     "includeCategories": true
   },


### PR DESCRIPTION
# Description

This PR adds type guards for various types returned from the WaniKani API. We also added missing schema for the `CreatedReview` type and a `datableString` method for parsing date strings to the `DatableString` type.

# Related Issue(s) / Pull Request(s)

e.g. `Closes #123` to close a related issue, or `See #456` to reference an existing issue or PR

# Nature of Pull Request

This Pull Request:

- [ ] Adds/Updates Type(s) described in the WaniKani API Docs
- [ ] Adds/Updates Type(s) provided by the `wanikani-api-types` package itself
- [ ] Adds/Updates constants or other variables provided by the package
- [x] Adds/Updates Helper Functions/Type Guards provided by the package
- [x] Updates Documentation
- [x] Updates Project and/or Community Health files (e.g. README, GitHub Actions, etc.)

Its changes constitutes a:

- [ ] Non-code change (i.e. no version bump)
- [ ] Bug Fix or Other Small Changes (i.e. patch version bump)
- [x] Forward-compatible Enhancement (i.e. minor version bump)
- [ ] ⚠️ BREAKING CHANGE regarding TypeScript, Package, and/or WaniKani API version(s) (i.e. MAJOR version bump)

# Additional Info

None

# Contribution Terms

I understand that by submitting this Pull Request:

- I agree to the terms outlined in the [Contribution Guidelines](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CONTRIBUTING.md) and [Code of Conduct](https://github.com/bachmacintosh/wanikani-api-types/blob/main/CODE_OF_CONDUCT.md)
- My code will be licensed for use in this repository per its [LICENSE](https://github.com/bachmacintosh/wanikani-api-types/blob/main/LICENSE), and that I have the right to license this code -- per GitHub's [Terms of Service](https://docs.github.com/en/site-policy/github-terms/github-terms-of-service#6-contributions-under-repository-license)
